### PR TITLE
v4.8 multicut & history scores on skipMove

### DIFF
--- a/src_files/TranspositionTable.cpp
+++ b/src_files/TranspositionTable.cpp
@@ -27,7 +27,6 @@
 void TranspositionTable::init(U64 MB) {
 
     U64 bytes      = MB * 1024 * 1024;
-    bytes *= 8;
     U64 maxEntries = bytes / sizeof(Entry);
 
     // size must be a power of 2!

--- a/src_files/makefile
+++ b/src_files/makefile
@@ -6,7 +6,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 7
+MINOR   = 8
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -812,8 +812,11 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
 
             Score betaCut = en.score - SE_MARGIN_STATIC - depth * 2;
             score         = pvSearch(b, betaCut - 1, betaCut, depth >> 1, ply, td, m);
-            if (score < betaCut)
+            if (score < betaCut) {
                 extension++;
+            } else if (en.score>=beta){
+                return en.score;
+            }
             b->getPseudoLegalMoves(mv);
             moveOrderer.setMovesPVSearch(mv, hashMove, sd, b, ply);
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -904,13 +904,13 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             if (!skipMove) {
                 // put the beta cutoff into the perft_tt
                 table->put(zobrist, score, m, CUT_NODE, depth);
-                // also set this move as a killer move into the history
-                sd->setKiller(m, ply, b->getActivePlayer());
-                // if the move is not a capture, we also update counter move history tables and history scores.
-                
-                sd->updateHistories(m, depth, mv, b->getActivePlayer(), b->getPreviousMove());
-                
             }
+            // also set this move as a killer move into the history
+            sd->setKiller(m, ply, b->getActivePlayer());
+            // if the move is not a capture, we also update counter move history tables and history scores.
+                
+            sd->updateHistories(m, depth, mv, b->getActivePlayer(), b->getPreviousMove());
+                
             return beta;
         }
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -151,8 +151,7 @@ bool rootTimeLeft() { return search_timeManager->rootTimeLeft(); }
  * @param hashSize
  */
 void search_setHashSize(int hashSize) {
-    delete table;
-    table = new TranspositionTable(hashSize);
+    table->setSize(hashSize);
 }
 
 /**

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -814,8 +814,12 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             score         = pvSearch(b, betaCut - 1, betaCut, depth >> 1, ply, td, m);
             if (score < betaCut) {
                 extension++;
-            } else if (en.score>=beta){
-                return en.score;
+            } else if (score>=beta){
+                return score;
+            } else if (en.score >= beta) {
+                score     = pvSearch(b, beta - 1, beta, depth >> 1, ply, td, m);
+                if (score>=beta) 
+                    return score;
             }
             b->getPseudoLegalMoves(mv);
             moveOrderer.setMovesPVSearch(mv, hashMove, sd, b, ply);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -712,7 +712,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // internal iterative deepening by Ed Schröder::
     // http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
     // **********************************************************************************************************
-    if (depth >= 4 && !hashMove)
+    if (depth >= 4 && !hashMove && !skipMove)
         depth--;
 
     // **********************************************************************************************************

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -712,7 +712,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // internal iterative deepening by Ed Schröder::
     // http://talkchess.com/forum3/viewtopic.php?f=7&t=74769&sid=64085e3396554f0fba414404445b3120
     // **********************************************************************************************************
-    if (depth >= 4 && !hashMove && !skipMove)
+    if (depth >= 4 && !hashMove)
         depth--;
 
     // **********************************************************************************************************
@@ -814,10 +814,10 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             score         = pvSearch(b, betaCut - 1, betaCut, depth >> 1, ply, td, m);
             if (score < betaCut) {
                 extension++;
-            } else if (score>=beta){
+            } else if (score >= beta){
                 return score;
             } else if (en.score >= beta) {
-                score     = pvSearch(b, beta - 1, beta, depth >> 1, ply, td, m);
+                score     = pvSearch(b, beta - 1, beta, (depth >> 1)+1, ply, td, m);
                 if (score>=beta) 
                     return score;
             }


### PR DESCRIPTION
ELO   | 7.63 +- 5.19 (95%)
SPRT  | 15.0+0.15s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8288 W: 2089 L: 1907 D: 4292