### PR TITLE
Beal effect based randomized draw eval.

### DIFF
--- a/src_files/makefile
+++ b/src_files/makefile
@@ -4,7 +4,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 31
+MINOR   = 32
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -608,7 +608,11 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     
     // if its a draw by 3-fold or 50-move rule, we return 0
     if (b->isDraw() && ply > 0) {
-        // To-Do. Idea originated in Stockfish.
+        // The idea of draw randomization originated in sf. According to conventional wisdom the key point is to force
+        // the search to explore different variations. For example in Stockfish and Ethereal the evaluation is 
+        // increased / decreased by 1 score grain.
+        // The implementation in Koivisto is based on a different idea, namely the Beal effect.
+        // (see https://www.chessprogramming.org/Search_with_Random_Leaf_Values).
         return 8 - (td->nodes & MASK_4);
     }
 
@@ -849,7 +853,9 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         int extension = 0;
         
         // *********************************************************************************************************
-        // singular extensions:
+        // singular extensions
+        // standard implementation apart from the fact that we cancel lmr of parent node in-case the node turns 
+        // out to be singular.
         // *********************************************************************************************************
         if (!extension && depth >= 8 && !skipMove && legalMoves == 0 && sameMove(m, hashMove) && ply > 0
             && en.zobrist == zobrist && abs(en.score) < MIN_MATE_SCORE

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -608,9 +608,10 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     
     // if its a draw by 3-fold or 50-move rule, we return 0
     if (b->isDraw() && ply > 0) {
-        return 0;
+        // To-Do. Idea originated in Stockfish.
+        return 1 - (td->nodes & 2);
     }
-    
+
     // beside keeping track of the nodes, we need to keep track of the selective depth for this thread.
     if (ply > td->seldepth) {
         td->seldepth = ply;

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -609,7 +609,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // if its a draw by 3-fold or 50-move rule, we return 0
     if (b->isDraw() && ply > 0) {
         // To-Do. Idea originated in Stockfish.
-        return 1 - (td->nodes & 2);
+        return 8 - (td->nodes & MASK_4);
     }
 
     // beside keeping track of the nodes, we need to keep track of the selective depth for this thread.


### PR DESCRIPTION
The idea of draw randomization originated in sf. According to conventional wisdom the key point is to force
the search to explore different variations. For example in Stockfish and Ethereal the evaluation is 
increased / decreased by 1 score grain.
The implementation in Koivisto is based on a different idea, namely the Beal effect.
(see https://www.chessprogramming.org/Search_with_Random_Leaf_Values).

Elo test for the Koivisto version against master (4moves_noob.pgn)
ELO   | 9.48 +- 5.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6304 W: 1619 L: 1447 D: 3238

Stockfish commit
https://github.com/official-stockfish/Stockfish/commit/97d2cc9a9c1c4b6ff1b470676fa18c7fc6509886

Ethereal commit
https://github.com/AndyGrant/Ethereal/commit/37ccbfe233ac418a49cb9a5c9f54d62b060d44ad