### PR TITLE
Hs no quiet on cap

### DIFF
--- a/src_files/History.cpp
+++ b/src_files/History.cpp
@@ -58,7 +58,7 @@ void SearchData::updateHistories(Move m, Depth depth, MoveList* mv, Color side, 
                 -(depth * depth + 5 * depth)
                 - (depth * depth + 5 * depth) * captureHistory[side][getSquareFrom(m2)][getSquareTo(m2)]
                       / MAX_HISTORY_SCORE;
-        } else {
+        } else if (!isCapture(m)) {
             history[side][getSquareFrom(m2)][getSquareTo(m2)] +=
                 -(depth * depth + 5 * depth)
                 - (depth * depth + 5 * depth) * history[side][getSquareFrom(m2)][getSquareTo(m2)] / MAX_HISTORY_SCORE;

--- a/src_files/makefile
+++ b/src_files/makefile
@@ -4,7 +4,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 32
+MINOR   = 33
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
bench: 8788450

ELO   | 5.44 +- 4.15 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13280 W: 3390 L: 3182 D: 6708

In addition to not updating quiet history if the cutoff comes from a capture, this also partially fixes an issue we had where moves that were pruned (late move pruning, etc.) would get a penalty if a later move failed high (which would often be a capture).