### PR TITLE
Null asym

### DIFF
--- a/src_files/makefile
+++ b/src_files/makefile
@@ -4,7 +4,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 33
+MINOR   = 34
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -675,7 +675,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             staticEval = en.score;
         }
         
-        if (!pv && en.depth >= depth) {
+        if (!pv && en.depth + (!b->getPreviousMove() && en.score >= beta)*100 >= depth) {
             if (en.type == PV_NODE) {
                 return en.score;
             } else if (en.type == CUT_NODE) {

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -675,6 +675,11 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             staticEval = en.score;
         }
         
+
+        // We treat child nodes of null moves differently. The reason a null move
+        // search has to be searched to great depth is to make sure that we dont
+        // cut in an unsafe way. Well if the nullmove search fails high, we dont cut anything,
+        // we still do a normal search. Thus the standard of proof required is different.
         if (!pv && en.depth + (!b->getPreviousMove() && en.score >= beta)*100 >= depth) {
             if (en.type == PV_NODE) {
                 return en.score;


### PR DESCRIPTION
bench: 9244272

Treat child nodes of null moves differently. The reason a null move search has to be searched to great depth is to make sure that we dont cut in an unsafe way. Well if the nullmove search fails high for our oponent, we dont cut anything, we still do a normal search. Thus the standard of proof required is different.

Elo test against master
ELO   | 7.92 +- 5.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7808 W: 2026 L: 1848 D: 3934

