### PR TITLE
Fix search stop tt saving issue

### DIFF
--- a/src_files/History.h
+++ b/src_files/History.h
@@ -74,7 +74,7 @@ struct ThreadData {
     U64 nodes    = 0;
     int seldepth = 0;
     int tbhits   = 0;
- 
+    bool dropOut = false;
     SearchData* searchData = nullptr;
     char padding[1024 * 128];
 

--- a/src_files/makefile
+++ b/src_files/makefile
@@ -4,7 +4,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 34
+MINOR   = 35
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -524,7 +524,7 @@ Move bestMove(Board* b, Depth maxDepth, TimeManager* timeManager, int threadId) 
     // will have a random position from the tree. Using this would lead to an illegal/not existing pv
     Board searchBoard{b};
     Board printBoard {b};
-    
+    td->dropOut = false;
     for (d = 1; d <= maxDepth; d++) {
         
         if (d < 6) {
@@ -603,6 +603,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // if the time is over, we fail hard to stop the search. We don't want to call the system clock too often for speed
     // reasons so we only apply this when the depth is larger than 10.
     if (depth > 6 && !isTimeLeft()) {
+        td->dropOut = true;
         return beta;
     }
     
@@ -963,7 +964,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         
         // beta -cutoff
         if (score >= beta) {
-            if (!skipMove) {
+            if (!skipMove && !td->dropOut) {
                 // put the beta cutoff into the perft_tt
                 table->put(zobrist, score, m, CUT_NODE, depth);
             }
@@ -1005,7 +1006,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     
     // we need to write the current score/position into the transposition table if and only if we havent skipped a move
     // due to our extension policy.
-    if (!skipMove) {
+    if (!skipMove && !td->dropOut) {
         if (alpha > originalAlpha) {
             table->put(zobrist, highestScore, bestMove, PV_NODE, depth);
         } else {


### PR DESCRIPTION
bench: 9244272
Fix issue where incorrect values could be written to tt when search is stopped. Measured no effect on single core performance, but gains with threads = 2.

ELO   | 4.40 +- 3.48 (95%)
SPRT  | 10.0+0.10s Threads=2 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18078 W: 4394 L: 4165 D: 9519
