### PR TITLE
Fix buffer overflow

### DIFF
--- a/src_files/TimeManager.cpp
+++ b/src_files/TimeManager.cpp
@@ -35,11 +35,7 @@ TimeManager::TimeManager(int moveTime) :
     upperTimeBound(moveTime), 
     ignorePV(true), 
     isSafeToStop(true), 
-    forceStop(), 
-    historyCount(), 
-    moveHistory(), 
-    scoreHistory(), 
-    depthHistory() {
+    forceStop() {
 
     startTime =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
@@ -56,11 +52,7 @@ TimeManager::TimeManager() :
     upperTimeBound(1 << 30), 
     ignorePV(true), 
     isSafeToStop(true), 
-    forceStop(), 
-    historyCount(), 
-    moveHistory(), 
-    scoreHistory(), 
-    depthHistory() {
+    forceStop() {
 
     startTime =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
@@ -85,11 +77,7 @@ TimeManager::TimeManager(int white, int black, int whiteInc, int blackInc, int m
     upperTimeBound(), 
     ignorePV(), 
     isSafeToStop(true), 
-    forceStop(), 
-    historyCount(), 
-    moveHistory(), 
-    scoreHistory(), 
-    depthHistory() {
+    forceStop() {
 
     double division = movesToGo+1;
 
@@ -138,13 +126,6 @@ void TimeManager::updatePV(Move move, Score score, Depth depth) {
     // dont keep track of pv changes if timing doesnt matter
     if (ignorePV)
         return;
-
-    // store the move,score,depth in the arrays
-    moveHistory[historyCount]  = move;
-    scoreHistory[historyCount] = score;
-    depthHistory[historyCount] = depth;
-
-    historyCount++;
 }
 
 /**

--- a/src_files/TimeManager.h
+++ b/src_files/TimeManager.h
@@ -49,11 +49,6 @@ class TimeManager {
     bool isSafeToStop;
     bool forceStop;
 
-    int   historyCount;
-    Move  moveHistory[256];
-    Score scoreHistory[256];
-    Depth depthHistory[256];
-
     /**
      * updates isSafeToStop
      */


### PR DESCRIPTION
Fixing crash issues. We observed crashes within `delete board` and `searchThread.join()`. Both crashes could be explained by undefined behaviour. This UB has been found to be within the timemanager. In rare situations, the history count goes out of bounds and we end if with a buffer overflow.

Theoretically this should not gain elo except for the crashes which cannot be observed anymore.

```
ELO   | 8.80 +- 6.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 4778 W: 1243 L: 1122 D: 2413
```