### PR TITLE
scale piecevalue vs history

### DIFF
--- a/src_files/movegen.cpp
+++ b/src_files/movegen.cpp
@@ -17,6 +17,7 @@
  *                                                                                                  *
  ****************************************************************************************************/
 #include "movegen.h"
+#include "psqt.h"
 #include "UCIAssert.h"
 
 
@@ -47,14 +48,9 @@ inline void scoreMove(Board* board, MoveList* mv, Move hashMove, SearchData* sd,
         
         if constexpr (isCapture){
             Score     SEE    = board->staticExchangeEvaluation(move);
-            MoveScore mvvLVA = 100 * (getCapturedPiece(move) % 8) - 10 * (getMovingPiece(move) % 8)
-                               + (getSquareTo(board->getPreviousMove()) == getSquareTo(move));
+            MoveScore mvvLVA = MgScore(piece_values[(getCapturedPiece(move) % 8)]);
             if (SEE >= 0) {
-                if (mvvLVA == 0) {
-                    mv->scoreMove(idx, 50000 + mvvLVA + sd->getHistories(move, board->getActivePlayer(), board->getPreviousMove()));
-                } else {
-                    mv->scoreMove(idx, 100000 + mvvLVA + sd->getHistories(move, board->getActivePlayer(), board->getPreviousMove()));
-                }
+                mv->scoreMove(idx, 100000 + mvvLVA + sd->getHistories(move, board->getActivePlayer(), board->getPreviousMove()));
             } else {
                 mv->scoreMove(idx, 10000 + sd->getHistories(move, board->getActivePlayer(), board->getPreviousMove()));
             }


### PR DESCRIPTION
bench: 7854273

The idea is to use piece values instead of 100 * piece type to scale better with history scores.

ELO   | 7.03 +- 5.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9192 W: 2371 L: 2185 D: 4636