### PR TITLE
Adjust aspiration window downward when failing low

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -554,6 +554,7 @@ Move bestMove(Board* b, Depth maxDepth, TimeManager* timeManager, int threadId) 
                     beta += window;
                 } else if (s <= alpha) {
                     alpha -= window;
+		    beta -= window / 2;
                 } else {
                     break;
                 }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -553,8 +553,8 @@ Move bestMove(Board* b, Depth maxDepth, TimeManager* timeManager, int threadId) 
                 if (s >= beta) {
                     beta += window;
                 } else if (s <= alpha) {
+		    beta = (alpha + beta) / 2;
                     alpha -= window;
-		    beta -= window / 2;
                 } else {
                     break;
                 }


### PR DESCRIPTION
ELO   | 3.61 +- 2.91 (95%)
SPRT  | 8+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 27105 W: 6862 L: 6580 D: 13663

The TLDR of the idea is to adjust the window to be more pessimistic when the score is failing low.