### PR TITLE
use threats in search (nmp)

### DIFF
--- a/src_files/eval.cpp
+++ b/src_files/eval.cpp
@@ -511,11 +511,11 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
     evalData.threats[WHITE] = PAWN_ATTACK_MINOR * bitCount(evalData.attacks[WHITE][PAWN] & (b->getPieceBB<BLACK>(KNIGHT) | b->getPieceBB<BLACK>(BISHOP)));
     evalData.threats[BLACK] = PAWN_ATTACK_MINOR * bitCount(evalData.attacks[BLACK][PAWN] & (b->getPieceBB<WHITE>(KNIGHT) | b->getPieceBB<WHITE>(BISHOP)));
 
-    evalData.threats[WHITE] += PAWN_ATTACK_ROOK * evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(ROOK);
-    evalData.threats[BLACK] += PAWN_ATTACK_ROOK * evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(ROOK);
+    evalData.threats[WHITE] += PAWN_ATTACK_ROOK * bitCount(evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(ROOK));
+    evalData.threats[BLACK] += PAWN_ATTACK_ROOK * bitCount(evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(ROOK));
 
-    evalData.threats[WHITE] += PAWN_ATTACK_QUEEN * evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(QUEEN);
-    evalData.threats[BLACK] += PAWN_ATTACK_QUEEN * evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(QUEEN);
+    evalData.threats[WHITE] += PAWN_ATTACK_QUEEN * bitCount(evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(QUEEN));
+    evalData.threats[BLACK] += PAWN_ATTACK_QUEEN * bitCount(evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(QUEEN));
 
     featureScore += PAWN_DOUBLED_AND_ISOLATED * (
             + bitCount(whiteIsolatedPawns & whiteDoubledPawns)

--- a/src_files/eval.cpp
+++ b/src_files/eval.cpp
@@ -682,7 +682,6 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
 
         evalData.threats[BLACK] += ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
 
-        featureScore -= ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
         featureScore -= SAFE_ROOK_CHECK * bitCount(wKingRookAttacks & attacks & ~evalData.attacks[WHITE][PAWN]);
 
         addToKingSafety(attacks, evalData.kingZone[WHITE], wkingSafety_attPiecesCount, wkingSafety_valueOfAttacks, 3);

--- a/src_files/eval.cpp
+++ b/src_files/eval.cpp
@@ -508,15 +508,15 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
     U64 mobilitySquaresBlack = ~blackTeam & ~(evalData.attacks[WHITE][PAWN]);
 
     // clang-format off
-    featureScore += PAWN_ATTACK_MINOR * (
-            + bitCount(evalData.attacks[WHITE][PAWN] & (b->getPieceBB<BLACK>(KNIGHT) | b->getPieceBB<BLACK>(BISHOP)))
-            - bitCount(evalData.attacks[BLACK][PAWN] & (b->getPieceBB<WHITE>(KNIGHT) | b->getPieceBB<WHITE>(BISHOP))));
-    featureScore += PAWN_ATTACK_ROOK  * (
-            + bitCount(evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(ROOK))
-            - bitCount(evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(ROOK)));
-    featureScore += PAWN_ATTACK_QUEEN * (
-            + bitCount(evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(QUEEN))
-            - bitCount(evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(QUEEN)));
+    evalData.threats[WHITE] = PAWN_ATTACK_MINOR * bitCount(evalData.attacks[WHITE][PAWN] & (b->getPieceBB<BLACK>(KNIGHT) | b->getPieceBB<BLACK>(BISHOP)));
+    evalData.threats[BLACK] = PAWN_ATTACK_MINOR * bitCount(evalData.attacks[BLACK][PAWN] & (b->getPieceBB<WHITE>(KNIGHT) | b->getPieceBB<WHITE>(BISHOP)));
+
+    evalData.threats[WHITE] += PAWN_ATTACK_ROOK * evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(ROOK);
+    evalData.threats[BLACK] += PAWN_ATTACK_ROOK * evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(ROOK);
+
+    evalData.threats[WHITE] += PAWN_ATTACK_QUEEN * evalData.attacks[WHITE][PAWN] & b->getPieceBB<BLACK>(QUEEN);
+    evalData.threats[BLACK] += PAWN_ATTACK_QUEEN * evalData.attacks[BLACK][PAWN] & b->getPieceBB<WHITE>(QUEEN);
+
     featureScore += PAWN_DOUBLED_AND_ISOLATED * (
             + bitCount(whiteIsolatedPawns & whiteDoubledPawns)
             - bitCount(blackIsolatedPawns & blackDoubledPawns));
@@ -556,11 +556,10 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
         attacks = KNIGHT_ATTACKS[square];
         evalData.attacks[WHITE][KNIGHT] |= attacks;
      
-        
         mobScore        += mobilityKnight[bitCount(KNIGHT_ATTACKS[square] & mobilitySquaresWhite)];
 
-        featureScore    += MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<BLACK>(ROOK));
-        featureScore    += MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
+        evalData.threats[WHITE] += MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<BLACK>(ROOK));
+        evalData.threats[WHITE] += MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
         featureScore    += KNIGHT_OUTPOST               * isOutpost(square, WHITE, blackPawns, evalData.attacks[WHITE][PAWN]);
         featureScore    += KNIGHT_DISTANCE_ENEMY_KING   * manhattanDistance(square, blackKingSquare);
         featureScore    += SAFE_KNIGHT_CHECK            * bitCount(bKingKnightAttacks & attacks & ~evalData.attacks[BLACK][PAWN]);
@@ -578,8 +577,8 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
     
         mobScore        -= mobilityKnight[bitCount(KNIGHT_ATTACKS[square] & mobilitySquaresBlack)];
 
-        featureScore    -= MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<WHITE>(ROOK));
-        featureScore    -= MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
+        evalData.threats[BLACK] += MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<WHITE>(ROOK));
+        evalData.threats[BLACK] += MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
         featureScore    -= KNIGHT_OUTPOST               * isOutpost(square, BLACK, whitePawns, evalData.attacks[BLACK][PAWN]);
         featureScore    -= KNIGHT_DISTANCE_ENEMY_KING   * manhattanDistance(square, whiteKingSquare);
         featureScore    -= SAFE_KNIGHT_CHECK            * bitCount(wKingKnightAttacks & attacks & ~evalData.attacks[WHITE][PAWN]);
@@ -601,8 +600,8 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
         
         mobScore        += mobilityBishop[bitCount(attacks & mobilitySquaresWhite)];
 
-        featureScore    += MINOR_ATTACK_ROOK    * bitCount(attacks & b->getPieceBB<BLACK>(ROOK));
-        featureScore    += MINOR_ATTACK_QUEEN   * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
+        evalData.threats[WHITE] += MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<BLACK>(ROOK));
+        evalData.threats[WHITE] += MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
         featureScore    += bishop_pawn_same_color_table_e[bitCount(blackPawns & (((ONE << square) & WHITE_SQUARES_BB) ? WHITE_SQUARES_BB : BLACK_SQUARES_BB))];
         featureScore    += bishop_pawn_same_color_table_o[bitCount(whitePawns & (((ONE << square) & WHITE_SQUARES_BB) ? WHITE_SQUARES_BB : BLACK_SQUARES_BB))];
         featureScore    += BISHOP_PIECE_SAME_SQUARE_E
@@ -628,8 +627,8 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
     
         mobScore        -= mobilityBishop[bitCount(attacks & mobilitySquaresBlack)];
 
-        featureScore    -= MINOR_ATTACK_ROOK * bitCount(attacks & b->getPieceBB<WHITE>(ROOK));
-        featureScore    -= MINOR_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
+        evalData.threats[BLACK] += MINOR_ATTACK_ROOK            * bitCount(attacks & b->getPieceBB<WHITE>(ROOK));
+        evalData.threats[BLACK] += MINOR_ATTACK_QUEEN           * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
         featureScore    -= bishop_pawn_same_color_table_e[bitCount(whitePawns & (((ONE << square) & WHITE_SQUARES_BB) ? WHITE_SQUARES_BB : BLACK_SQUARES_BB))];
         featureScore    -= bishop_pawn_same_color_table_o[bitCount(blackPawns & (((ONE << square) & WHITE_SQUARES_BB) ? WHITE_SQUARES_BB : BLACK_SQUARES_BB))];
         featureScore    -= BISHOP_PIECE_SAME_SQUARE_E
@@ -664,7 +663,8 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
 
         mobScore += mobilityRook[bitCount(attacks & mobilitySquaresWhite)];
 
-        featureScore += ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
+        evalData.threats[WHITE] += ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<BLACK>(QUEEN));
+
         featureScore += SAFE_ROOK_CHECK * bitCount(bKingRookAttacks & attacks & ~evalData.attacks[BLACK][PAWN]);
 
         addToKingSafety(attacks, evalData.kingZone[BLACK], bkingSafety_attPiecesCount, bkingSafety_valueOfAttacks, 3);
@@ -679,6 +679,8 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
         evalData.attacks[BLACK][ROOK] |= attacks;
 
         mobScore -= mobilityRook[bitCount(attacks & mobilitySquaresBlack)];
+
+        evalData.threats[BLACK] += ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
 
         featureScore -= ROOK_ATTACK_QUEEN * bitCount(attacks & b->getPieceBB<WHITE>(QUEEN));
         featureScore -= SAFE_ROOK_CHECK * bitCount(wKingRookAttacks & attacks & ~evalData.attacks[WHITE][PAWN]);
@@ -779,7 +781,7 @@ bb::Score Evaluator::evaluate(Board* b, Score alpha, Score beta) {
                        - b->getCastlingRights(STATUS_INDEX_BLACK_QUEENSIDE_CASTLING)
                        - b->getCastlingRights(STATUS_INDEX_BLACK_KINGSIDE_CASTLING));
     featureScore += SIDE_TO_MOVE             * (b->getActivePlayer() == WHITE ? 1 : -1);
-    EvalScore totalScore = evalScore + pinnedEvalScore + hangingEvalScore + featureScore + mobScore + passedScore;
+    EvalScore totalScore = evalScore + pinnedEvalScore + hangingEvalScore + featureScore + mobScore + passedScore + evalData.threats[WHITE] - evalData.threats[BLACK];
     res += (int) ((float) MgScore(totalScore) * (1 - phase));
     res += (int) ((float) EgScore(totalScore) * (phase));
 

--- a/src_files/eval.h
+++ b/src_files/eval.h
@@ -50,6 +50,7 @@ struct EvalData{
     U64 semiOpen        [N_COLORS]{};
     U64 pawnEastAttacks [N_COLORS]{};
     U64 pawnWestAttacks [N_COLORS]{};
+    Score threats       [N_COLORS]{};
     
 };
 

--- a/src_files/eval.h
+++ b/src_files/eval.h
@@ -50,7 +50,7 @@ struct EvalData{
     U64 semiOpen        [N_COLORS]{};
     U64 pawnEastAttacks [N_COLORS]{};
     U64 pawnWestAttacks [N_COLORS]{};
-    Score threats       [N_COLORS]{};
+    EvalScore threats   [N_COLORS]{};
     
 };
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -42,7 +42,7 @@ int lmrReductions[256][256];
 ThreadData tds[MAX_THREADS]{};
 
 int RAZOR_MARGIN     = 198;
-int FUTILITY_MARGIN  = 82;
+int FUTILITY_MARGIN  = 92;
 int SE_MARGIN_STATIC = 0;
 int LMR_DIV          = 215;
 
@@ -774,7 +774,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // if the static evaluation is already above beta with a specific margin, assume that the we will definetly be
         // above beta and stop the search here and fail soft
         // **********************************************************************************************************
-        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN && staticEval < MIN_MATE_SCORE)
+        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN / (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2) && staticEval < MIN_MATE_SCORE)
             return staticEval;
         
         // **********************************************************************************************************

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -776,16 +776,13 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // **********************************************************************************************************
         if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN && staticEval < MIN_MATE_SCORE)
             return staticEval;
-
-        if (depth == 1 && sd->evaluator.evalData.threats[!b->getActivePlayer()] == 0 && staticEval >= beta + 15)
-            return staticEval;
         
         // **********************************************************************************************************
         // futlity pruning:
         // if the evaluation from a very shallow search after doing nothing is still above beta, we assume that we are
         // currently above beta as well and stop the search early.
         // **********************************************************************************************************
-        if (staticEval >= beta + (5 > depth ? 30 : 0) && !hasOnlyPawns(b, b->getActivePlayer())) {
+        if (staticEval >= beta + (5 > depth ? 30 : 0) && sd->evaluator.evalData.threats[!b->getActivePlayer()] == 0 && !hasOnlyPawns(b, b->getActivePlayer())) {
             b->move_null();
             score = -pvSearch(b, -beta, 1 - beta, depth - (depth / 4 + 3) * ONE_PLY - (staticEval-beta<300 ? (staticEval-beta)/FUTILITY_MARGIN : 3), ply + ONE_PLY, td, 0);
             b->undoMove_null();

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -42,7 +42,7 @@ int lmrReductions[256][256];
 ThreadData tds[MAX_THREADS]{};
 
 int RAZOR_MARGIN     = 198;
-int FUTILITY_MARGIN  = 92;
+int FUTILITY_MARGIN  = 82;
 int SE_MARGIN_STATIC = 0;
 int LMR_DIV          = 215;
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -774,7 +774,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // if the static evaluation is already above beta with a specific margin, assume that the we will definetly be
         // above beta and stop the search here and fail soft
         // **********************************************************************************************************
-        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN / (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2) && staticEval < MIN_MATE_SCORE)
+        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN /*/ (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2)*/ && staticEval < MIN_MATE_SCORE)
             return staticEval;
         
         // **********************************************************************************************************

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -782,7 +782,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // if the evaluation from a very shallow search after doing nothing is still above beta, we assume that we are
         // currently above beta as well and stop the search early.
         // **********************************************************************************************************
-        if (staticEval >= beta + (5 > depth ? 30 : 0) && sd->evaluator.evalData.threats[!b->getActivePlayer()] == 0 && !hasOnlyPawns(b, b->getActivePlayer())) {
+        if (staticEval >= beta + (5 > depth ? 30 : 0) && !(depth < 5 && sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0) && !hasOnlyPawns(b, b->getActivePlayer())) {
             b->move_null();
             score = -pvSearch(b, -beta, 1 - beta, depth - (depth / 4 + 3) * ONE_PLY - (staticEval-beta<300 ? (staticEval-beta)/FUTILITY_MARGIN : 3), ply + ONE_PLY, td, 0);
             b->undoMove_null();

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -774,7 +774,10 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // if the static evaluation is already above beta with a specific margin, assume that the we will definetly be
         // above beta and stop the search here and fail soft
         // **********************************************************************************************************
-        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN / (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2) && staticEval < MIN_MATE_SCORE)
+        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN && staticEval < MIN_MATE_SCORE)
+            return staticEval;
+
+        if (depth == 1 && sd->evaluator.evalData.threats[!b->getActivePlayer()] == 0 && staticEval >= beta + 15)
             return staticEval;
         
         // **********************************************************************************************************

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -774,7 +774,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         // if the static evaluation is already above beta with a specific margin, assume that the we will definetly be
         // above beta and stop the search here and fail soft
         // **********************************************************************************************************
-        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN /*/ (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2)*/ && staticEval < MIN_MATE_SCORE)
+        if (depth <= 7 && staticEval >= beta + depth * FUTILITY_MARGIN / (sd->evaluator.evalData.threats[!b->getActivePlayer()] > 0 ? 1 : 2) && staticEval < MIN_MATE_SCORE)
             return staticEval;
         
         // **********************************************************************************************************


### PR DESCRIPTION
bench: 8794612

ELO   | 6.32 +- 4.61 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10448 W: 2597 L: 2407 D: 5444

Reuse evaluation information in search - dont do shallow qs if oponent has threats.