### PR TITLE
Pbcut confirmation

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -799,14 +799,14 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // probcut was first implemented in StockFish by Gary Linscott. See https://www.chessprogramming.org/ProbCut.
     // **********************************************************************************************************
 
-    Score betaCut = staticEval + FUTILITY_MARGIN;
+    Score betaCut = beta + FUTILITY_MARGIN;
     if (!inCheck && !pv && depth > 4 && !skipMove) {
         generateNonQuietMoves(b, mv, hashMove, sd, ply);
         MoveOrderer moveOrderer {mv};
         while (moveOrderer.hasNext()) {
             // get the current move
             Move m = moveOrderer.next();
-            if ((see_piece_vals[getCapturedPiece(m) % 8] < 50 + betaCut - staticEval && !(isPromotion && (promotionPiece(m) % 8 == QUEEN))) || b->staticExchangeEvaluation(m) < 1)
+            if (b->staticExchangeEvaluation(m) < ((isPromotion && (promotionPiece(m) % 8 == QUEEN)) ? 0 : std::max(1, betaCut - staticEval)))
                 continue;
 
             if (!b->isLegal(m))
@@ -817,7 +817,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             Score score = -qSearch(b, -betaCut, -betaCut+1, ply + 1, td);
             
             if (score >= betaCut)
-                score = -pvSearch(b, -betaCut, -betaCut+1, depth - 4, ply+1, td, m);
+                score = -pvSearch(b, -betaCut, -betaCut+1, depth - 4, ply+1, td, 0);
 
             b->undoMove();
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -800,14 +800,12 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // **********************************************************************************************************
 
     Score betaCut = beta + FUTILITY_MARGIN;
-    if (!inCheck && !pv && depth > 4 && !skipMove) {
+    if (!inCheck && !pv && depth > 4 && !skipMove && !(hashMove && en.depth >= depth - 3 && en.score < betaCut)) {
         generateNonQuietMoves(b, mv, hashMove, sd, ply);
         MoveOrderer moveOrderer {mv};
         while (moveOrderer.hasNext()) {
             // get the current move
             Move m = moveOrderer.next();
-            if (b->staticExchangeEvaluation(m) < ((isPromotion && (promotionPiece(m) % 8 == QUEEN)) ? 0 : std::max(1, betaCut - staticEval)))
-                continue;
 
             if (!b->isLegal(m))
                 continue;
@@ -822,7 +820,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             b->undoMove();
 
             if (score >= betaCut) {
-                table->put(zobrist, score, m, CUT_NODE, depth - 4);
+                table->put(zobrist, score, m, CUT_NODE, depth - 3);
                 return betaCut;
             }
 


### PR DESCRIPTION
bench: 8120354

ELO   | 4.46 +- 3.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17782 W: 4356 L: 4128 D: 9298

Probcut. As far as chess engines go first implemeted in Stockfish by Gary Linscott.