### PR TITLE
Score history

### DIFF
--- a/src_files/History.cpp
+++ b/src_files/History.cpp
@@ -32,6 +32,8 @@ void SearchData::updateHistories(Move m, Depth depth, MoveList* mv, Color side, 
     for (int i = 0; i < mv->getSize(); i++) {
         m2 = mv->getMove(i);
 
+        int score = mv->getScore(i);
+
         Piece  movingPiece = getMovingPiece(m2) % 8;
         Square squareTo    = getSquareTo(m2);
 
@@ -55,16 +57,16 @@ void SearchData::updateHistories(Move m, Depth depth, MoveList* mv, Color side, 
             return;
         } else if (isCapture(m2)) {
             captureHistory[side][getSquareFrom(m2)][getSquareTo(m2)] +=
-                -(depth * depth + 5 * depth)
-                - (depth * depth + 5 * depth) * captureHistory[side][getSquareFrom(m2)][getSquareTo(m2)]
+                -(score * score + 5 * score)
+                - (score * score + 5 * score) * captureHistory[side][getSquareFrom(m2)][getSquareTo(m2)]
                       / MAX_HISTORY_SCORE;
         } else if (!isCapture(m)) {
             history[side][getSquareFrom(m2)][getSquareTo(m2)] +=
-                -(depth * depth + 5 * depth)
-                - (depth * depth + 5 * depth) * history[side][getSquareFrom(m2)][getSquareTo(m2)] / MAX_HISTORY_SCORE;
+                -(score * score + 5 * score)
+                - (score * score + 5 * score) * history[side][getSquareFrom(m2)][getSquareTo(m2)] / MAX_HISTORY_SCORE;
             cmh[prevPiece][prevTo][color][movingPiece][squareTo] +=
-                -(depth * depth + 5 * depth)
-                - (depth * depth + 5 * depth) * cmh[prevPiece][prevTo][color][movingPiece][squareTo]
+                -(score * score + 5 * score)
+                - (score * score + 5 * score) * cmh[prevPiece][prevTo][color][movingPiece][squareTo]
                       / MAX_HISTORY_SCORE;
         }
     }

--- a/src_files/MoveOrderer.h
+++ b/src_files/MoveOrderer.h
@@ -28,9 +28,9 @@ class MoveOrderer {
 
     private:
     move::MoveList* moves;
-    int             counter;
 
     public:
+    int             counter;
     bool skip;
     
     MoveOrderer(move::MoveList* p_moves);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -876,7 +876,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         
         if (ply > 0 && legalMoves >= 1 && highestScore > -MIN_MATE_SCORE) {
             
-            Depth moveDepth = depth-lmrReductions[depth][legalMoves];
+            Depth moveDepth = std::max(1, depth-lmrReductions[depth][legalMoves]-1);
             
             if (quiet) {
                 quiets++;

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -973,6 +973,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             lmr = lmr - sd->getHistories(m, b->getActivePlayer(), b->getPreviousMove()) / 150;
             lmr += !isImproving;
             lmr -= pv;
+            lmr++;
             if (sd->isKiller(m, ply, b->getActivePlayer())) lmr--;
             if (sd->reduce && sd->sideToReduce != b->getActivePlayer()) lmr++;
             if (lmr > MAX_PLY) {

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -991,7 +991,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         if (extension == 0 && b->isInCheck(b->getActivePlayer()))
             extension = 1;
         
-        mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
+        mv->scoreMove(moveOrderer.counter-1, depth);
 
         // principal variation search recursion.
         if (legalMoves == 0) {
@@ -999,11 +999,9 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         } else {
             score = -pvSearch(b, -alpha - 1, -alpha, depth - ONE_PLY - lmr + extension, ply + ONE_PLY, td, 0, &lmr);
             if (pv) sd->reduce = true;
-            if (lmr && score > alpha) {
-                mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
+            if (lmr && score > alpha) 
                 score = -pvSearch(b, -alpha - 1, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td,
                     0);    // re-search
-            }
             if (score > alpha && score < beta)
                 score = -pvSearch(b, -beta, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td,
                                   0);    // re-search

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -991,11 +991,12 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         if (extension == 0 && b->isInCheck(b->getActivePlayer()))
             extension = 1;
         
+        mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
+
         // principal variation search recursion.
         if (legalMoves == 0) {
             score = -pvSearch(b, -beta, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td, 0);
         } else {
-            mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
             score = -pvSearch(b, -alpha - 1, -alpha, depth - ONE_PLY - lmr + extension, ply + ONE_PLY, td, 0, &lmr);
             if (pv) sd->reduce = true;
             if (lmr && score > alpha) {

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -995,11 +995,14 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         if (legalMoves == 0) {
             score = -pvSearch(b, -beta, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td, 0);
         } else {
+            mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
             score = -pvSearch(b, -alpha - 1, -alpha, depth - ONE_PLY - lmr + extension, ply + ONE_PLY, td, 0, &lmr);
             if (pv) sd->reduce = true;
-            if (lmr && score > alpha)
+            if (lmr && score > alpha) {
+                mv->scoreMove(moveOrderer.counter-1, depth - lmr + extension);
                 score = -pvSearch(b, -alpha - 1, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td,
-                                  0);    // re-search
+                    0);    // re-search
+            }
             if (score > alpha && score < beta)
                 score = -pvSearch(b, -beta, -alpha, depth - ONE_PLY + extension, ply + ONE_PLY, td,
                                   0);    // re-search


### PR DESCRIPTION
bench: 6440063

ELO   | 5.06 +- 3.88 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14424 W: 3497 L: 3287 D: 7640

Fix bug that caused history scores to be updated for moves that werent even searched.