### PR TITLE
TT Replacement Scheme for already stored positions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(Koivisto
         src_files/material.h
         src_files/material.cpp)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMINOR_VERSION=65")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMINOR_VERSION=66")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAJOR_VERSION=4")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")

--- a/src_files/TranspositionTable.cpp
+++ b/src_files/TranspositionTable.cpp
@@ -134,7 +134,7 @@ bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type,
         enP->setAge(m_currentAge);
         return true;
     } else {
-        if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == zobrist && enP->depth < depth + 4)) {
+        if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == zobrist && enP->depth < depth * 2)) {
             enP->set(zobrist, score, move, type, depth);
             enP->setAge(m_currentAge);
             return true;

--- a/src_files/TranspositionTable.cpp
+++ b/src_files/TranspositionTable.cpp
@@ -134,7 +134,7 @@ bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type,
         enP->setAge(m_currentAge);
         return true;
     } else {
-        if (enP->getAge() != m_currentAge || type == PV_NODE || ((enP->type != PV_NODE||enP->zobrist == zobrist) && enP->depth <= depth)) {
+        if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == zobrist && enP->depth < depth + 4)) {
             enP->set(zobrist, score, move, type, depth);
             enP->setAge(m_currentAge);
             return true;

--- a/src_files/makefile
+++ b/src_files/makefile
@@ -4,7 +4,7 @@ LIBS    = -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 FOLDER  = bin/
 ROOT    = ../
 NAME    = Koivisto
-MINOR   = 65
+MINOR   = 66
 MAJOR   = 4
 EXE     = $(ROOT)$(FOLDER)$(NAME)_$(MAJOR).$(MINOR)
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
Bench: 7866109

ELO   | 6.34 +- 4.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9968 W: 2318 L: 2136 D: 5514

ELO   | 2.83 +- 2.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 25644 W: 5839 L: 5630 D: 14175

This was run in 2 phases. First test results are from a static margin, second test results are an improvement over that with a variable margin.

The idea behind this replacement scheme is to allow faster searches of subtrees by allowing more localized search results to be stored in the TT. A hard replacement scheme has been tested on another engine, and has been shown to be worse (there is a limit to how great of a depth override should occur). 

This idea of replacement can be found in many strong engines (SF and Ethereal), however they use a static margin. Martin (author of Cheng) tested and validated a variable margin.