### PR TITLE
Speedupthingy

### DIFF
--- a/src_files/MoveOrderer.cpp
+++ b/src_files/MoveOrderer.cpp
@@ -32,10 +32,16 @@ MoveOrderer::~MoveOrderer() {}
 
 bool MoveOrderer::hasNext() { return counter < moves->getSize(); }
 
-move::Move MoveOrderer::next() {
-    if (skip) {
-        moves->scoreMove(counter, 0);
-        return moves->getMove(counter++);
+move::Move MoveOrderer::next(U64 kingBB) {
+    if (skip) {    
+        for (int i = counter; i < moves->getSize(); i++) {
+            moves->scoreMove(i, 0);
+            if (isCapture(moves->getMove(i)) || (kingBB & (ONE << getSquareTo(moves->getMove(i))))) {
+                counter = i+1;
+                return moves->getMove(i);
+            }
+        }
+        return 0;
     }
     int bestIndex = counter;
     // Move best = moves->getMove(0);

--- a/src_files/MoveOrderer.h
+++ b/src_files/MoveOrderer.h
@@ -39,7 +39,7 @@ class MoveOrderer {
     
     bool hasNext();
 
-    move::Move next();
+    move::Move next(U64 kingBB);
 };
 
 #endif    // KOIVISTO_MOVEORDERER_H

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -907,7 +907,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             // if the depth we are going to search the move at is small enough and the static exchange evaluation for the given move is very negative, dont
             // consider this quiet move as well.
             // ******************************************************************************************************
-            if (moveDepth <= 5 && (getCapturedPieceType(m)) < (getMovingPieceType(m))
+            if (moveDepth <= 5 && (getCapturedPieceType(m)) < (getMovingPieceType(m) || quiet)
                 && b->staticExchangeEvaluation(m) <= (quiet ? -40*moveDepth : -100 * moveDepth))
                 continue;
         }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -814,7 +814,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
         MoveOrderer moveOrderer {mv};
         while (moveOrderer.hasNext()) {
             // get the current move
-            Move m = moveOrderer.next();
+            Move m = moveOrderer.next(0);
             
             if (!b->isLegal(m))
                 continue;
@@ -867,13 +867,18 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
     // count the legal and quiet moves.
     int legalMoves = 0;
     int quiets     = 0;
+
+    Square kingSq  = bitscanForward(b->getPieceBB(!b->getActivePlayer(), KING));
+    U64 kingBB     = *BISHOP_ATTACKS[kingSq] | *ROOK_ATTACKS[kingSq] | KNIGHT_ATTACKS[kingSq];
     
     // loop over all moves in the movelist
     while (moveOrderer.hasNext()) {
         
         // get the current move
-        Move m = moveOrderer.next();
+        Move m = moveOrderer.next(kingBB);
         
+        if (!m) break;
+
         // if the move is the move we want to skip, skip this move (used for extensions)
         if (sameMove(m, skipMove))
             continue;
@@ -907,7 +912,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             // if the depth we are going to search the move at is small enough and the static exchange evaluation for the given move is very negative, dont
             // consider this quiet move as well.
             // ******************************************************************************************************
-            if (moveDepth <= 5 && (getCapturedPieceType(m)) < (getMovingPieceType(m) || quiet)
+            if (moveDepth <= 5 && (getCapturedPieceType(m)) < (getMovingPieceType(m))
                 && b->staticExchangeEvaluation(m) <= (quiet ? -40*moveDepth : -100 * moveDepth))
                 continue;
         }
@@ -953,7 +958,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             generateMoves(b, mv, hashMove, sd, ply);
             moveOrderer = {mv};
             
-            m = moveOrderer.next();
+            m = moveOrderer.next(0);
         }
         
         // *********************************************************************************************************
@@ -1174,7 +1179,7 @@ Score qSearch(Board* b, Score alpha, Score beta, Depth ply, ThreadData* td, bool
     
     for (int i = 0; i < mv->getSize(); i++) {
         
-        Move m = moveOrderer.next();
+        Move m = moveOrderer.next(0);
         
         // do not consider illegal moves
         if (!b->isLegal(m))


### PR DESCRIPTION
bench: 7102479

ELO   | 4.94 +- 3.82 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14756 W: 3548 L: 3338 D: 7870

only return moves that are either possibly giving check or captures from moveorderer when moverorderer.skip is true.