### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -1033,6 +1033,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             if (ply == 0 && (isTimeLeft() || depth <= 2) && td->threadID == 0) {
                 // Store bestMove for bestMove
                 sd->bestMove = m;
+                alpha = highestScore;
             }
         }
         


### PR DESCRIPTION
bench: 7325398
ELO   | 4.51 +- 3.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16016 W: 3535 L: 3327 D: 9154

decrease alpha if highestscore at root is below alpha