### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -921,7 +921,7 @@ Score pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply, Thread
             // if the depth we are going to search the move at is small enough and the static exchange evaluation for the given move is very negative, dont
             // consider this quiet move as well.
             // ******************************************************************************************************
-            if (moveDepth <= 5 && (getCapturedPieceType(m)) < (getMovingPieceType(m))
+            if (moveDepth <= 5 + quiet*3 && (getCapturedPieceType(m)) < (getMovingPieceType(m))
                 && b->staticExchangeEvaluation(m) <= (quiet ? -40*moveDepth : -100 * moveDepth))
                 continue;
         }


### PR DESCRIPTION
bench: 7259326
ELO   | 3.52 +- 2.83 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 24584 W: 5372 L: 5123 D: 14089

Increase maximum allowed depth for quiet see pruning