### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -42,7 +42,7 @@ int lmrReductions[256][256];
 ThreadData tds[MAX_THREADS]{};
 
 int RAZOR_MARGIN     = 198;
-int FUTILITY_MARGIN  = 92;
+int FUTILITY_MARGIN  = 85;
 int SE_MARGIN_STATIC = 0;
 int LMR_DIV          = 215;
 


### PR DESCRIPTION
bench: 6513398
ELO   | 3.75 +- 3.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22248 W: 4954 L: 4714 D: 12580
Handtune