### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -44,7 +44,7 @@ int                      lmrReductions[256][256];
 ThreadData               tds[MAX_THREADS] {};
 
 int                      RAZOR_MARGIN     = 198;
-int                      FUTILITY_MARGIN  = 92;
+int                      FUTILITY_MARGIN  = 81;
 int                      SE_MARGIN_STATIC = 0;
 int                      LMR_DIV          = 215;
 


### PR DESCRIPTION
bench: 8076320
ELO   | 3.91 +- 3.07 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 18752 W: 3694 L: 3483 D: 11575