### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -630,8 +630,8 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         }
 
         // compute the static exchange evaluation if the move is a capture
-        Score staticExchangeEval = 0;
-        if (isCapture(m) && (getCapturedPieceType(m)) < (getMovingPieceType(m))) {
+        Score staticExchangeEval = 1;
+        if (isCapture(m) && (getCapturedPieceType(m)) <= (getMovingPieceType(m))) {
             staticExchangeEval = b->staticExchangeEvaluation(m);
         }
 
@@ -688,7 +688,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // compute the lmr based on the depth, the amount of legal moves etc.
         // we dont want to reduce if its the first move we search, or a capture with a positive see
         // score or if the depth is too small. furthermore no queen promotions are reduced
-        Depth lmr       = (legalMoves < 2 || depth <= 2 || (isCapture(m) && staticExchangeEval >= 0)
+        Depth lmr       = (legalMoves < 2 || depth <= 2 || (isCapture(m) && staticExchangeEval > 0)
                      || (isPromotion && (getPromotionPieceType(m) == QUEEN)))
                               ? 0
                               : lmrReductions[depth][legalMoves];


### PR DESCRIPTION
bench: 5636056
ELO   | 2.74 +- 2.21 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30168 W: 4910 L: 4672 D: 20586

Do lmr on equal captures