### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -597,7 +597,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 }
                 
                 // prune quiet moves that are unlikely to improve alpha
-                if (!inCheck && moveDepth == 1 && sd->maxImprovement[getSquareFrom(m)][getSquareTo(m)] +  30 + sd->eval[b->getActivePlayer()][ply] < alpha)
+                if (!inCheck && moveDepth < 3 && sd->maxImprovement[getSquareFrom(m)][getSquareTo(m)] +  30 + sd->eval[b->getActivePlayer()][ply] < alpha)
                     continue;
                 
                 // **************************************************************************************************


### PR DESCRIPTION
bench: 5195242
ELO   | 2.54 +- 2.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 35064 W: 5625 L: 5369 D: 24070

Prune for movedepth == 2 as well.