### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -600,6 +600,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 if (!inCheck && moveDepth < 3 && sd->maxImprovement[getSquareFrom(m)][getSquareTo(m)] +  30 + sd->eval[b->getActivePlayer()][ply] < alpha)
                     continue;
                 
+                // prune quiet moves that are unlikely to improve alpha
+                if (!inCheck && moveDepth <= 7 && sd->maxImprovement[getSquareFrom(m)][getSquareTo(m)] +  moveDepth * FUTILITY_MARGIN + 100 + sd->eval[b->getActivePlayer()][ply] < alpha)
+                    continue;
+
                 // **************************************************************************************************
                 // history pruning:
                 // if the history score for a move is really bad at low depth, dont consider this


### PR DESCRIPTION
bench: 4507384
ELO   | 3.84 +- 2.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16544 W: 2637 L: 2454 D: 11453
Futility pruning for quiet moves. No need for extra eval work if move will get static null move pruned anyway.