### PR TITLE
test

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -670,9 +670,6 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             moveOrderer = {mv};
 
             m           = moveOrderer.next(0);
-        } else if (depth < 8) {
-            if (legalMoves == 1 && hashMove && en.type == CUT_NODE && getSquareFrom(hashMove) == getSquareTo(sd->killer[!b->getActivePlayer()][ply + 1][0]))
-                extension = 1;
         }
         // *********************************************************************************************************
         // kk reductions:


### PR DESCRIPTION
bench: 4348724
ELO   | 1.26 +- 2.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 16848 W: 2527 L: 2466 D: 11855
Simplify away evasion extension