### PR TITLE
cost vs benefit for early iterations

### DIFF
--- a/src_files/History.h
+++ b/src_files/History.h
@@ -49,7 +49,7 @@ struct SearchData {
     Score    eval[N_COLORS][MAX_INTERNAL_PLY]                                    = {0};
     bool     sideToReduce;
     bool     reduce;
-
+    bool     targetReached                                                       = 1;
     void     updateHistories(Move m, Depth depth, MoveList* mv, Color side, Move previous);
 
     int      getHistories(Move m, Color side, Move previous);

--- a/src_files/TimeManager.cpp
+++ b/src_files/TimeManager.cpp
@@ -21,6 +21,7 @@
 #include "TimeManager.h"
 #include "Board.h"
 #include "UCIAssert.h"
+#include "History.h"
 
 auto startTime =
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -125,7 +126,7 @@ void TimeManager::stopSearch() { forceStop = true; }
 /**
  * returns true if there is enough time left. This is used by the principal variation search.
  */
-bool TimeManager::isTimeLeft() {
+bool TimeManager::isTimeLeft(SearchData* sd) {
 
 
     // stop the search if requested
@@ -133,7 +134,15 @@ bool TimeManager::isTimeLeft() {
         return false;
     
     int elapsed = elapsedTime();
-
+    
+    if (sd != nullptr && mode == TOURNAMENT) {
+        if (elapsed * 10 < timeToUse) {
+           sd->targetReached = false;
+        } else {
+            sd->targetReached = true;
+        }
+    }
+    
     // if we are above the maximum allowed time, stope  
     if (elapsed >= upperTimeBound)
         return false;

--- a/src_files/TimeManager.h
+++ b/src_files/TimeManager.h
@@ -22,6 +22,7 @@
 
 #include "Board.h"
 #include "Move.h"
+#include "History.h"
 
 using namespace move;
 using namespace bb;
@@ -67,7 +68,7 @@ class TimeManager {
      * returns true if the search should continue. false otherwise.
      * @return
      */
-    bool isTimeLeft();
+    bool isTimeLeft(SearchData* sd = nullptr);
     
     /**
      * checks if time at the root is left

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -292,7 +292,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
 
     // if the time is over, we fail hard to stop the search. We don't want to call the system clock
     // too often for speed reasons so we only apply this when the depth is larger than 6.
-    if ((depth > 6 && !isTimeLeft())) {
+    if ((depth > 6 && !isTimeLeft(&td->searchData))) {
         td->dropOut = true;
         return beta;
     }
@@ -704,6 +704,8 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             lmr = lmr - history / 150;
             lmr += !isImproving;
             lmr -= pv;
+            if (!sd->targetReached) 
+                lmr++;
             if (sd->isKiller(m, ply, b->getActivePlayer()))
                 lmr--;
             if (sd->reduce && sd->sideToReduce != b->getActivePlayer())
@@ -1031,7 +1033,7 @@ U64 Search::tbHits() {
     }
     return th;
 }
-bool           Search::isTimeLeft() { return timeManager->isTimeLeft(); }
+bool           Search::isTimeLeft(SearchData* sd) { return timeManager->isTimeLeft(sd); }
 bool           Search::rootTimeLeft(int score) { return timeManager->rootTimeLeft(score); }
 SearchOverview Search::overview() { return this->searchOverview; }
 void           Search::enableInfoStrings() { this->printInfo = true; }

--- a/src_files/search.h
+++ b/src_files/search.h
@@ -74,7 +74,7 @@ class Search {
     int  selDepth();
     U64  tbHits();
 
-    bool isTimeLeft();
+    bool isTimeLeft(SearchData* sd = nullptr);
     bool rootTimeLeft(int score);
 
     public:


### PR DESCRIPTION
bench: 4849425
ELO   | 4.44 +- 3.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13864 W: 2309 L: 2132 D: 9423
reduce more early on. The idea is that we need to consider cost vs benefit for early iterations. Cost = time spent while benefit is mostly in move ordering. Thus the optimal search for early iterations could be very different from late iterations.