### PR TITLE
movedepth

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -582,7 +582,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
 
         if (ply > 0 && legalMoves >= 1 && highestScore > -MIN_MATE_SCORE) {
 
-            Depth moveDepth = std::max(1, depth - lmrReductions[depth][legalMoves]);
+            Depth moveDepth = std::max(1, 1 + depth - lmrReductions[depth][legalMoves]);
 
             if (quiet) {
                 quiets++;


### PR DESCRIPTION
bench: 4438231
ELO   | 4.24 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14192 W: 2155 L: 1982 D: 10055
Just increase movedepth variable used in pruning by 1