### PR TITLE
Improvingstnmp

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -450,11 +450,11 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // will definetly be above beta and stop the search here and fail soft. Also reuse information
         // from eval to prevent pruning if the oponent has multiple threats.
         // **********************************************************************************************************
-        if (depth <= 7 && enemyThreats < 2 && staticEval >= beta + (depth - isImproving) * FUTILITY_MARGIN
+        if (depth <= 7 && enemyThreats < 2 && staticEval >= beta + (depth - (isImproving && !enemyThreats)) * FUTILITY_MARGIN
             && staticEval < MIN_MATE_SCORE)
             return staticEval;
 
-            
+
         // **********************************************************************************************************
         // threat pruning:
         // if the static evaluation is already above beta at depth 1 and we have strong threats, asume


### PR DESCRIPTION
bench: 4249148
Introduce Improving condition to static null move pruning but with additional enemy threat condition
tested twice
ELO   | 10.44 +- 5.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4496 W: 688 L: 553 D: 3255

ELO   | 6.02 +- 4.00 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9000 W: 1479 L: 1323 D: 6198