### PR TITLE
limit check extension at low depth

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -729,7 +729,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
 
         // adjust the extension policy for checks. we could use the givesCheck value but it has not
         // been validated to work 100%
-        if (extension == 0 && b->isInCheck(b->getActivePlayer()))
+        if (extension == 0 && depth > 4 && b->isInCheck(b->getActivePlayer()))
             extension = 1;
 
         mv->scoreMove(moveOrderer.counter - 1, depth + (staticEval < alpha));


### PR DESCRIPTION
bench: 3978465
tested twice

ELO   | 5.18 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10456 W: 1556 L: 1400 D: 7500

ELO   | 7.57 +- 4.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6520 W: 987 L: 845 D: 4688