### PR TITLE
tt hashMove updating tweak

### DIFF
--- a/src_files/TranspositionTable.h
+++ b/src_files/TranspositionTable.h
@@ -38,6 +38,7 @@ constexpr NodeType PV_NODE  = 0;
 constexpr NodeType CUT_NODE = 1;
 constexpr NodeType ALL_NODE = 2;
 constexpr NodeType FORCED_ALL_NODE = 3;
+constexpr NodeType FORMER_CUT_NODE = 6;
 
 struct Entry {
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -856,7 +856,9 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         if (alpha > originalAlpha) {
             table->put(zobrist, highestScore, bestMove, PV_NODE, depth);
         } else {
-            if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
+            if (hashMove && en.type == CUT_NODE) {
+                table->put(zobrist, highestScore, en.move, FORMER_CUT_NODE, depth);
+            } else if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
                 table->put(zobrist, highestScore, bestMove, FORCED_ALL_NODE, depth);
             } else {
                 table->put(zobrist, highestScore, bestMove, ALL_NODE, depth);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -734,7 +734,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         if (extension == 0 && depth > 4 && b->isInCheck(b->getActivePlayer()))
             extension = 1;
 
-        if (sameMove(hashMove, m) && !pv && en.type == FORCED_ALL_NODE)
+        if (sameMove(hashMove, m) && !pv && en.type > ALL_NODE)
             extension = 1;
 
         mv->scoreMove(moveOrderer.counter - 1, depth + (staticEval < alpha));

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -856,9 +856,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         if (alpha > originalAlpha) {
             table->put(zobrist, highestScore, bestMove, PV_NODE, depth);
         } else {
-            if (hashMove && en.type == CUT_NODE) {
-                table->put(zobrist, highestScore, en.move, FORMER_CUT_NODE, depth);
-            } else if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
+            if (hashMove && en.type == CUT_NODE)
+                bestMove = en.move;
+            
+            if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
                 table->put(zobrist, highestScore, bestMove, FORCED_ALL_NODE, depth);
             } else {
                 table->put(zobrist, highestScore, bestMove, ALL_NODE, depth);


### PR DESCRIPTION
bench: 3918242

tested twice as usual
ELO   | 4.34 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13464 W: 1990 L: 1822 D: 9652

ELO   | 2.85 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 24752 W: 3533 L: 3330 D: 17889
