### PR TITLE
tweak hashMove updates further

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -856,8 +856,11 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         if (alpha > originalAlpha) {
             table->put(zobrist, highestScore, bestMove, PV_NODE, depth);
         } else {
-            if (hashMove && en.type == CUT_NODE)
+            if (hashMove && en.type == CUT_NODE) {
                 bestMove = en.move;
+            } else if (score == alpha) {
+                bestMove = 0;
+            }
             
             if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
                 table->put(zobrist, highestScore, bestMove, FORCED_ALL_NODE, depth);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -858,7 +858,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         } else {
             if (hashMove && en.type == CUT_NODE) {
                 bestMove = en.move;
-            } else if (score == alpha) {
+            } else if (score == alpha && !sameMove(hashMove, bestMove)) {
                 bestMove = 0;
             }
             


### PR DESCRIPTION
bench: 3759474

tested twice as usual:
ELO   | 5.40 +- 3.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9648 W: 1358 L: 1208 D: 7082

ELO   | 5.83 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8824 W: 1218 L: 1070 D: 6536
