### PR TITLE
tweak singular extension

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -646,10 +646,9 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // node turns out to be singular. Also standard multi-cut.
         // *********************************************************************************************************
         if (depth >= 8 && !skipMove && legalMoves == 0 && sameMove(m, hashMove) && ply > 0 && !inCheck
-            && en.zobrist == zobrist && abs(en.score) < MIN_MATE_SCORE
-            && (en.type == CUT_NODE || en.type == PV_NODE) && en.depth >= depth - 3) {
+            && abs(en.score) < MIN_MATE_SCORE && (en.type == CUT_NODE || en.type == PV_NODE) && en.depth >= depth - 3) {
 
-            betaCut = en.score - SE_MARGIN_STATIC - depth * 2;
+            betaCut = std::min((int)(en.score - SE_MARGIN_STATIC - depth * 2), (int)beta);
             score   = pvSearch(b, betaCut - 1, betaCut, depth >> 1, ply, td, m, behindNMP);
             if (score < betaCut) {
                 if (lmrFactor != nullptr) {


### PR DESCRIPTION
bench: 3532578

make sure we don't singularly extend just because the best move is super winning

tested twice as usual
ELO   | 6.58 +- 3.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7448 W: 999 L: 858 D: 5591

ELO   | 7.84 +- 4.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6248 W: 906 L: 765 D: 4577