### PR TITLE
Time managment tweak

### DIFF
--- a/src_files/TimeManager.cpp
+++ b/src_files/TimeManager.cpp
@@ -84,8 +84,8 @@ TimeManager::TimeManager(int white, int black, int whiteInc, int blackInc, int m
 
     double division = movesToGo+1;
 
-    upperTimeBound = board->getActivePlayer() == WHITE ? (int(white / division)*3 + whiteInc) - 25
-                                                       : (int(black / division)*3 + blackInc) - 25;
+    upperTimeBound = board->getActivePlayer() == WHITE ? (int(white / division)*3 + std::min(white * 0.9 + whiteInc, whiteInc * 1.5) - 25)
+                                                       : (int(black / division)*3 + std::min(black * 0.9 + blackInc, blackInc * 1.5) - 25);
 
     timeToUse = upperTimeBound / 3;
 


### PR DESCRIPTION
bench: 3318120

Use a larger portion of the increment each move.

Tested at stc & ltc
ELO   | 2.61 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27288 W: 3537 L: 3332 D: 20419
ELO   | 3.46 +- 2.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14240 W: 1227 L: 1085 D: 11928