### PR TITLE
Fix searching hashMove as killer too & slight tweak to staged movegen

### DIFF
--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -80,6 +80,10 @@ Move moveGen::next() {
                 return m_killer2;
 
         case GEN_QUIET:
+            if (shouldSkip()) {
+                stage = GET_BAD_NOISY;
+                return next();
+            }
             generateQuiet();
             stage++;
 

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -499,3 +499,7 @@ void moveGen::updateHistory(int weight) {
 void moveGen::skip() {
     m_skip = true;
 }
+
+bool moveGen::shouldSkip() {
+    return m_skip;
+}

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -62,6 +62,8 @@ Move moveGen::next() {
                 return 0;
             if (m_mode == Q_SEARCHCHECK) {
                 stage = QS_EVASIONS;
+                m_killer1 = 0;
+                m_killer2 = 0;
                 generateEvasions();
                 if (quiet_index < quietSize)
                     return nextQuiet();
@@ -71,12 +73,12 @@ Move moveGen::next() {
 
         case KILLER1:
             stage++;
-            if (m_board->isPseudoLegal(m_killer1))
+            if (!sameMove(m_killer1, m_hashMove) && m_board->isPseudoLegal(m_killer1))
                 return m_killer1;
 
         case KILLER2:
             stage++;
-            if (m_board->isPseudoLegal(m_killer2))
+            if (!sameMove(m_killer2, m_hashMove) && m_board->isPseudoLegal(m_killer2))
                 return m_killer2;
 
         case GEN_QUIET:
@@ -109,7 +111,7 @@ Move moveGen::next() {
 }
 
 void moveGen::addNoisy(Move m) {
-    if (sameMove(m_hashMove, m) | sameMove(m_killer1, m) | sameMove(m_killer2, m))
+    if (sameMove(m_hashMove, m))
         return;
     int score   = (isPromotion(m) && (getPromotionPieceType(m) != QUEEN)) ? 
               - 1 : m_board->staticExchangeEvaluation(m);

--- a/src_files/newmovegen.h
+++ b/src_files/newmovegen.h
@@ -92,6 +92,7 @@ class moveGen {
     void generateEvasions();
     void updateHistory(int weight);
     void skip();
+    bool shouldSkip();
 };
 
 #endif

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -783,7 +783,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 table->put(zobrist, score, m, CUT_NODE, depth);
             }
             // also set this move as a killer move into the history
-            if (!isCapture(m))
+            if (!isCapture(m) && !isPromotion)
                 sd->setKiller(m, ply, b->getActivePlayer());
 
             // update history scores

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -582,9 +582,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 // if the depth is small enough and we searched enough quiet moves, dont consider this
                 // move
                 // **************************************************************************************************
-                if (depth <= 7 && quiets > lmp[isImproving][depth]) {
-                    mGen->skip();
+                if (mGen->shouldSkip())
                     continue;
+                if (depth <= 7 && quiets >= lmp[isImproving][depth]) {
+                    mGen->skip();
                 }
                 
                 // prune quiet moves that are unlikely to improve alpha


### PR DESCRIPTION
bench: 3510714

Tweak first tested: 
ELO   | 2.94 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22072 W: 2844 L: 2657 D: 16571

Then tested the fix ontop of that:
ELO   | 3.35 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 18448 W: 2376 L: 2198 D: 13874

Then tested combined twice against master: 
ELO   | 5.15 +- 3.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9992 W: 1314 L: 1166 D: 7512

ELO   | 4.52 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12152 W: 1634 L: 1476 D: 9042