### PR TITLE
store eval in tt

### DIFF
--- a/src_files/Bitboard.h
+++ b/src_files/Bitboard.h
@@ -31,6 +31,7 @@ namespace bb {
 #define mirrorSquare(s) (bb::squareIndex(7 - bb::rankIndex(s), bb::fileIndex(s)))
 
 typedef uint64_t U64;
+typedef uint32_t U32;
 typedef int8_t   Square;
 typedef int8_t   Diagonal;
 typedef int8_t   AntiDiagonal;

--- a/src_files/Perft.cpp
+++ b/src_files/Perft.cpp
@@ -129,7 +129,7 @@ U64 perft(Board* b, int depth, bool print, bool d1, bool hash, int ply) {
     }
 
     if (hash) {
-        perft_tt->put(zob, 0, nodes, 0, depth);
+        perft_tt->put(zob, 0, nodes, 0, depth, 0);
     }
 
     return nodes;

--- a/src_files/TranspositionTable.cpp
+++ b/src_files/TranspositionTable.cpp
@@ -125,12 +125,12 @@ Entry TranspositionTable::get(U64 zobrist) {
  */
 bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type, Depth depth) {
 
-    U64 index = zobrist & m_mask;
-
+    U64 index  = zobrist & m_mask;
     Entry* enP = &m_entries[index];
+    U32 key    = zobrist >> 32;
 
     if (enP->zobrist == 0) {
-        enP->set(zobrist, score, move, type, depth);
+        enP->set(key, score, move, type, depth);
         enP->setAge(m_currentAge);
         return true;
     } else {
@@ -143,8 +143,8 @@ bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type,
         //  This idea of replacement can be found in many strong engines (SF and Ethereal), however they use a static margin. 
         //  Martin (author of Cheng) tested and validated a variable margin.
 
-        if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == zobrist && enP->depth <= depth * 2)) {
-            enP->set(zobrist, score, move, type, depth);
+        if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == key && enP->depth <= depth * 2)) {
+            enP->set(key, score, move, type, depth);
             enP->setAge(m_currentAge);
             return true;
         }

--- a/src_files/TranspositionTable.cpp
+++ b/src_files/TranspositionTable.cpp
@@ -123,14 +123,14 @@ Entry TranspositionTable::get(U64 zobrist) {
  * @param depth
  * @return
  */
-bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type, Depth depth) {
+bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type, Depth depth, Score eval) {
 
     U64 index  = zobrist & m_mask;
     Entry* enP = &m_entries[index];
     U32 key    = zobrist >> 32;
 
     if (enP->zobrist == 0) {
-        enP->set(key, score, move, type, depth);
+        enP->set(key, score, move, type, depth, eval);
         enP->setAge(m_currentAge);
         return true;
     } else {
@@ -144,7 +144,7 @@ bool TranspositionTable::put(U64 zobrist, Score score, Move move, NodeType type,
         //  Martin (author of Cheng) tested and validated a variable margin.
 
         if (enP->getAge() != m_currentAge || type == PV_NODE || (enP->type != PV_NODE && enP->depth <= depth) || (enP->zobrist == key && enP->depth <= depth * 2)) {
-            enP->set(key, score, move, type, depth);
+            enP->set(key, score, move, type, depth, eval);
             enP->setAge(m_currentAge);
             return true;
         }

--- a/src_files/TranspositionTable.h
+++ b/src_files/TranspositionTable.h
@@ -51,8 +51,8 @@ struct Entry {
         return os;
     }
 
-    void set(U64 p_zobrist, Score p_score, Move p_move, NodeType p_type, Depth p_depth) {
-        this->zobrist = p_zobrist;
+    void set(U32 p_key, Score p_score, Move p_move, NodeType p_type, Depth p_depth) {
+        this->zobrist = p_key;
         this->score   = p_score;
         this->move    = p_move;
         this->type    = p_type;
@@ -63,11 +63,12 @@ struct Entry {
 
     void setAge(NodeAge p_age) { setScore(move, p_age); }
 
-    U64      zobrist;    // 64 bit
+    U32      zobrist;    // 32 bit
     Move     move;       // 32 bit  (using the 8 msb for age)
     Depth    depth;      // 8 bit
     NodeType type;       // 8 bit
-    Score    score;      // 16 bit -> 128 bit = 16 byte
+    Score    score;      // 16 bit
+    Score    eval;  	 // 16 bit -> 112 bit = 14 byte
 };
 
 class TranspositionTable {

--- a/src_files/TranspositionTable.h
+++ b/src_files/TranspositionTable.h
@@ -51,12 +51,13 @@ struct Entry {
         return os;
     }
 
-    void set(U32 p_key, Score p_score, Move p_move, NodeType p_type, Depth p_depth) {
+    void set(U32 p_key, Score p_score, Move p_move, NodeType p_type, Depth p_depth, Score p_eval) {
         this->zobrist = p_key;
         this->score   = p_score;
         this->move    = p_move;
         this->type    = p_type;
         this->depth   = p_depth;
+        this->eval    = p_eval;
     }
 
     NodeAge getAge() { return getScore(move); }
@@ -93,7 +94,7 @@ class TranspositionTable {
 
     Entry get(U64 zobrist);
 
-    bool put(U64 zobrist, Score score, Move move, NodeType type, Depth depth);
+    bool put(U64 zobrist, Score score, Move move, NodeType type, Depth depth, Score eval);
 
     void incrementAge();
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -881,7 +881,7 @@ Score Search::qSearch(Board* b, Score alpha, Score beta, Depth ply, ThreadData* 
 
     // extract information like search data (history tables), zobrist etc
     SearchData* sd         = &td->searchData;
-    U32         key        = b->zobrist();
+    U64         key        = b->zobrist();
     Entry       en         = table->get(b->zobrist());
     NodeType    ttNodeType = ALL_NODE;
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -535,7 +535,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             b->undoMove();
 
             if (qScore >= betaCut) {
-                table->put(key, qScore, m, CUT_NODE, depth - 3, staticEval);
+                table->put(key, qScore, m, CUT_NODE, depth - 3, sd->eval[b->getActivePlayer()][ply]);
                 return betaCut;
             }
         }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -401,6 +401,12 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         ownThreats   = sd->threatCount[ply][b->getActivePlayer()];
         enemyThreats = sd->threatCount[ply][!b->getActivePlayer()];
         mainThreat   = sd->mainThreat[ply];
+        if (ply > 0 && b->getPreviousMove() != 0) {
+            if (sd->eval[!b->getActivePlayer()][ply - 1] > -TB_WIN_SCORE) {
+                int improvement =  -staticEval - sd->eval[!b->getActivePlayer()][ply - 1];
+                sd->maxImprovement[getSquareFrom(b->getPreviousMove())][getSquareTo(b->getPreviousMove())] = improvement;
+            }
+        }
     }
 
     // we check if the evaluation improves across plies.
@@ -604,7 +610,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 }
                 
                 // prune quiet moves that are unlikely to improve alpha
-                if (!inCheck && moveDepth <= 7 && moveDepth * FUTILITY_MARGIN + 100 + sd->eval[b->getActivePlayer()][ply] < alpha)
+                if (!inCheck && moveDepth <= 7 && sd->maxImprovement[getSquareFrom(m)][getSquareTo(m)] + moveDepth * FUTILITY_MARGIN + 100 + sd->eval[b->getActivePlayer()][ply] < alpha)
                     continue;
 
                 // **************************************************************************************************

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -403,6 +403,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         mainThreat   = sd->mainThreat[ply];
     }
 
+    // we check if the evaluation improves across plies.
+    sd->setHistoricEval(staticEval, b->getActivePlayer(), ply);
+    bool  isImproving = inCheck ? false : sd->isImproving(staticEval, b->getActivePlayer(), ply);
+
     if (en.zobrist == key >> 32) {
         // adjusting eval
         if ((en.type == PV_NODE) || (en.type == CUT_NODE && staticEval < en.score)
@@ -411,10 +415,6 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             staticEval = en.score;
         }
     } 
-
-    // we check if the evaluation improves across plies.
-    sd->setHistoricEval(staticEval, b->getActivePlayer(), ply);
-    bool  isImproving = inCheck ? false : sd->isImproving(staticEval, b->getActivePlayer(), ply);
 
     // **************************************************************************************************************
     // tablebase probing:


### PR DESCRIPTION
bench: 3410432

The main benefit of this is that it frees some bits for other stuff too, that we might wana do later (stored part of the key is now 32 bit instead of 64). 

tested twice as usual
ELO   | 1.41 +- 0.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 128544 W: 16167 L: 15646 D: 96731

ELO   | 6.14 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8032 W: 1060 L: 918 D: 6054
