### PR TITLE
Time managment tweak

### DIFF
--- a/src_files/TimeManager.cpp
+++ b/src_files/TimeManager.cpp
@@ -84,8 +84,8 @@ TimeManager::TimeManager(int white, int black, int whiteInc, int blackInc, int m
 
     double division = movesToGo+1;
 
-    upperTimeBound = board->getActivePlayer() == WHITE ? (int(white / division)*3 + std::min(white * 0.9 + whiteInc, whiteInc * 1.5) - 25)
-                                                       : (int(black / division)*3 + std::min(black * 0.9 + blackInc, blackInc * 1.5) - 25);
+    upperTimeBound = board->getActivePlayer() == WHITE ? (int(white / division)*3 + std::min(white * 0.9 + whiteInc, whiteInc * 3.0) - 25)
+                                                       : (int(black / division)*3 + std::min(black * 0.9 + blackInc, blackInc * 3.0) - 25);
 
     timeToUse = upperTimeBound / 3;
 


### PR DESCRIPTION
bench: 3237237

Tested at both std and ltc:
ELO   | 4.76 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10952 W: 1393 L: 1243 D: 8316

ELO   | 4.48 +- 2.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10248 W: 855 L: 723 D: 8670

Using a bigger portion of the increment each move.
