### PR TITLE
tune some search params

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -35,10 +35,10 @@ using namespace attacks;
 
 int  lmrReductions[256][256];
 
-int  RAZOR_MARGIN     = 198;
-int  FUTILITY_MARGIN  = 81;
+int  RAZOR_MARGIN     = 243;
+int  FUTILITY_MARGIN  = 68;
 int  SE_MARGIN_STATIC = 0;
-int  LMR_DIV          = 215;
+int  LMR_DIV          = 267;
 
 int  lmp[2][8]        = {{0, 2, 3, 5, 8, 12, 17, 23}, {0, 3, 6, 9, 12, 18, 28, 40}};
 


### PR DESCRIPTION
bench: 3599833

tested twice as usual:
ELO   | 4.19 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13200 W: 1688 L: 1529 D: 9983

ELO   | 1.82 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 53992 W: 6678 L: 6395 D: 40919