### PR TITLE
fix timeman for cyclic tc

### DIFF
--- a/src_files/TimeManager.cpp
+++ b/src_files/TimeManager.cpp
@@ -53,7 +53,7 @@ void TimeManager::setMatchTimeLimit (U64 time, U64 inc, int moves_to_go) {
     const double  division = 2;
     
     U64 upperTimeBound = time / 2;
-    U64 timeToUse      = 2 * inc + time / 10;
+    U64 timeToUse      = 2 * inc + 2 * time / moves_to_go;
     
     timeToUse          = std::min(time - inc, timeToUse);
     upperTimeBound     = std::min(time - inc, upperTimeBound);

--- a/src_files/uci.cpp
+++ b/src_files/uci.cpp
@@ -474,7 +474,7 @@ void uci::go(const std::vector<std::string>& split, const std::string& str) {
         U64 btime = (btime_str.empty()) ? 60000000 : stoi(btime_str);
         U64 wincr = (wincr_str.empty()) ?        0 : stoi(wincr_str);
         U64 bincr = (bincr_str.empty()) ?        0 : stoi(bincr_str);
-        int mvtog = (mvtog_str.empty()) ?       22 : stoi(mvtog_str);
+        int mvtog = (mvtog_str.empty()) ?       20 : stoi(mvtog_str);
         
         timeManager.setMatchTimeLimit(board.getActivePlayer() == WHITE ? wtime : btime,
                                       board.getActivePlayer() == WHITE ? wincr : bincr,


### PR DESCRIPTION
bench:  3647046
ELO   | 15.81 +- 8.24 (95%)
SPRT  | 40/8.0+0.00s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3496 W: 975 L: 816 D: 1705
ELO   | 5.78 +- 4.37 (95%)
SPRT  | 40/8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12512 W: 3336 L: 3128 D: 6048
ELO   | 2.99 +- 4.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 9888 W: 2471 L: 2386 D: 5031