### PR TITLE
Speedup givesCheck

### DIFF
--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -122,7 +122,7 @@ Move moveGen::next() {
 void moveGen::addNoisy(Move m) {
     if (sameMove(m_hashMove, m))
         return;
-    int score   = m_mode ? m_board->staticExchangeEvaluation(m) : (getCapturedPieceType(m) < getMovingPieceType(m) ? m_board->staticExchangeEvaluation(m) : 1);
+    int score   = m_board->staticExchangeEvaluation(m);
     noisySee[noisySize] = score;
     int mvvLVA  = piece_values[(getCapturedPieceType(m))];
     if (score >= 0) {

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -122,7 +122,7 @@ Move moveGen::next() {
 void moveGen::addNoisy(Move m) {
     if (sameMove(m_hashMove, m))
         return;
-    int score   = m_board->staticExchangeEvaluation(m);
+    int score   = m_mode ? m_board->staticExchangeEvaluation(m) : (getCapturedPieceType(m) < getMovingPieceType(m) ? m_board->staticExchangeEvaluation(m) : 1);
     noisySee[noisySize] = score;
     int mvvLVA  = piece_values[(getCapturedPieceType(m))];
     if (score >= 0) {

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -625,9 +625,9 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
     }
     
     Square      kingSq     = bitscanForward(b->getPieceBB(!b->getActivePlayer(), KING));
+    U64         kingCBB    = *BISHOP_ATTACKS[kingSq] | *ROOK_ATTACKS[kingSq] | KNIGHT_ATTACKS[kingSq];
     mGen->init(sd, b, ply, hashMove, b->getPreviousMove(), b->getPreviousMove(2),
-               PV_SEARCH, mainThreat,
-               *BISHOP_ATTACKS[kingSq] | *ROOK_ATTACKS[kingSq] | KNIGHT_ATTACKS[kingSq]);
+               PV_SEARCH, mainThreat, kingCBB);
     // count the legal and quiet moves.
     int         legalMoves      = 0;
     int         quiets          = 0;
@@ -642,7 +642,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             continue;
 
         // check if the move gives check and/or its promoting
-        bool givesCheck  = b->givesCheck(m);
+        bool givesCheck  = ((ONE << getSquareTo(m)) & kingCBB) ? b->givesCheck(m) : 0;
         bool isPromotion = move::isPromotion(m);
         bool quiet       = !isCapture(m) && !isPromotion && !givesCheck;
 
@@ -745,8 +745,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                     return score;
             }
             mGen->init(sd, b, ply, hashMove, b->getPreviousMove(),
-                       b->getPreviousMove(2), PV_SEARCH, mainThreat,
-                       *BISHOP_ATTACKS[kingSq] | *ROOK_ATTACKS[kingSq] | KNIGHT_ATTACKS[kingSq]);
+                       b->getPreviousMove(2), PV_SEARCH, mainThreat, kingCBB);
             m = mGen->next();
         }
         // *******************************************************************************************


### PR DESCRIPTION
bench: 3760568

tested twice as usual: 
ELO   | 2.84 +- 2.15 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 49712 W: 12550 L: 12144 D: 25018

ELO   | 3.32 +- 2.41 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 39632 W: 10049 L: 9670 D: 19913