### PR TITLE
Additional speedups

### DIFF
--- a/src_files/Board.cpp
+++ b/src_files/Board.cpp
@@ -1004,12 +1004,14 @@ bool Board::isLegal(Move m) {
         opponentBishopBitboard = m_piecesBB[WHITE_BISHOP];
     }
     
+    Square sqFrom = getSquareFrom(m);
+
     if (isEnPassant(m)) {
-        this->move(m);
+        unsetBit(m_occupiedBB, sqFrom);
         bool isOk =
             (attacks::lookUpRookAttacks(thisKing, m_occupiedBB) & (opponentQueenBitboard | opponentRookBitboard)) == 0
             && (attacks::lookUpBishopAttacks(thisKing, m_occupiedBB) & (opponentQueenBitboard | opponentBishopBitboard)) == 0;
-        this->undoMove();
+        setBit(m_occupiedBB, sqFrom);
         
         return isOk;
     } else if (isCastle(m)) {
@@ -1025,7 +1027,6 @@ bool Board::isLegal(Move m) {
         }
     }
     
-    Square sqFrom = getSquareFrom(m);
     Square sqTo   = getSquareTo(m);
     bool   isCap  = isCapture(m);
     

--- a/src_files/Board.cpp
+++ b/src_files/Board.cpp
@@ -1003,15 +1003,13 @@ bool Board::isLegal(Move m) {
         opponentRookBitboard   = m_piecesBB[WHITE_ROOK];
         opponentBishopBitboard = m_piecesBB[WHITE_BISHOP];
     }
-    
-    Square sqFrom = getSquareFrom(m);
 
     if (isEnPassant(m)) {
-        unsetBit(m_occupiedBB, sqFrom);
+        this->move(m);
         bool isOk =
             (attacks::lookUpRookAttacks(thisKing, m_occupiedBB) & (opponentQueenBitboard | opponentRookBitboard)) == 0
             && (attacks::lookUpBishopAttacks(thisKing, m_occupiedBB) & (opponentQueenBitboard | opponentBishopBitboard)) == 0;
-        setBit(m_occupiedBB, sqFrom);
+        this->undoMove();
         
         return isOk;
     } else if (isCastle(m)) {
@@ -1027,6 +1025,7 @@ bool Board::isLegal(Move m) {
         }
     }
     
+    Square sqFrom = getSquareFrom(m);
     Square sqTo   = getSquareTo(m);
     bool   isCap  = isCapture(m);
     

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -584,7 +584,6 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
     }
     
     Square      kingSq     = bitscanForward(b->getPieceBB(!b->getActivePlayer(), KING));
-    Square      okingSq    = bitscanForward(b->getPieceBB(b->getActivePlayer(), KING));
     U64         occupiedBB = b->getOccupiedBB();
     U64         kingCBB    = attacks::lookUpBishopAttacks(kingSq, occupiedBB) 
                            | attacks::lookUpRookAttacks(kingSq, occupiedBB) 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -589,10 +589,6 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
     U64         kingCBB    = attacks::lookUpBishopAttacks(kingSq, occupiedBB) 
                            | attacks::lookUpRookAttacks(kingSq, occupiedBB) 
                            | KNIGHT_ATTACKS[kingSq];
-    U64         okingCBB   = attacks::lookUpBishopAttacks(okingSq, occupiedBB) 
-                           | attacks::lookUpRookAttacks(okingSq, occupiedBB) 
-                           | KNIGHT_ATTACKS[okingSq] 
-                           | b->getPieceBB(b->getActivePlayer(), KING);
     mGen->init(sd, b, ply, hashMove, b->getPreviousMove(), b->getPreviousMove(2),
                PV_SEARCH, mainThreat, kingCBB);
     // count the legal and quiet moves.
@@ -664,7 +660,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         }
 
         // dont search illegal moves
-        if ((inCheck || ((ONE << getSquareFrom(m)) & okingCBB)) ? !b->isLegal(m) : 0) {
+        if (!b->isLegal(m)) {
             quiets -= quiet;
             continue;
         }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -137,47 +137,6 @@ void initLMR() {
     }
 }
 
-//void computeLMR(SearchData* sd, Board* board, int legalMoves, Move hashMove, bool pv, Depth depth, Depth ply, Move m, Score see){
-//
-//    // compute the lmr based on the depth, the amount of legal moves etc.
-//    // we dont want to reduce if its the first move we search, or a capture with a positive see
-//    // score or if the depth is too small. furthermore no queen promotions are reduced
-//    Depth lmr       = (legalMoves < 2 - (hashMove != 0) + pv || depth <= 2
-//                 || (isCapture(m) && see > 0)
-//                 || (isPromotion && (getPromotionPieceType(m) == QUEEN)))
-//                    ? 0
-//                    : lmrReductions[depth][legalMoves];
-//
-//    // increase reduction if we are behind a null move, depending on which side we are looking at.
-//    // this is a sound reduction in theory.
-//    if (legalMoves > 0 && depth > 2 && b->getActivePlayer() == behindNMP)
-//        lmr++;
-//
-//    // depending on if lmr is used, we adjust the lmr score using history scores and kk-reductions
-//    // etc. Most conditions are standard and should be considered self explanatory.
-//    if (lmr) {
-//        int history = sd->getHistories(m, board->getActivePlayer(), board->getPreviousMove(),
-//                                       ply > 1 ? sd->playedMoves[ply - 2] : 0, mainThreat);
-//        lmr         = lmr - history / 150;
-//        lmr += !isImproving;
-//        lmr -= pv;
-//        if (!sd->targetReached)
-//            lmr++;
-//        if (sd->isKiller(m, ply, board->getActivePlayer()))
-//            lmr--;
-//        if (sd->reduce && sd->sideToReduce != board->getActivePlayer())
-//            lmr++;
-//        if (lmr > MAX_PLY) {
-//            lmr = 0;
-//        }
-//        if (lmr > depth - 2) {
-//            lmr = depth - 2;
-//        }
-//        if (history > 256*(2-isCapture(m)))
-//            lmr = 0;
-//    }
-//}
-
 /**
  * returns the best move for the given board.
  * the search will stop if either the max depth is reached.
@@ -625,7 +584,15 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
     }
     
     Square      kingSq     = bitscanForward(b->getPieceBB(!b->getActivePlayer(), KING));
-    U64         kingCBB    = *BISHOP_ATTACKS[kingSq] | *ROOK_ATTACKS[kingSq] | KNIGHT_ATTACKS[kingSq];
+    Square      okingSq    = bitscanForward(b->getPieceBB(b->getActivePlayer(), KING));
+    U64         occupiedBB = b->getOccupiedBB();
+    U64         kingCBB    = attacks::lookUpBishopAttacks(kingSq, occupiedBB) 
+                           | attacks::lookUpRookAttacks(kingSq, occupiedBB) 
+                           | KNIGHT_ATTACKS[kingSq];
+    U64         okingCBB   = attacks::lookUpBishopAttacks(okingSq, occupiedBB) 
+                           | attacks::lookUpRookAttacks(okingSq, occupiedBB) 
+                           | KNIGHT_ATTACKS[okingSq] 
+                           | b->getPieceBB(b->getActivePlayer(), KING);
     mGen->init(sd, b, ply, hashMove, b->getPreviousMove(), b->getPreviousMove(2),
                PV_SEARCH, mainThreat, kingCBB);
     // count the legal and quiet moves.
@@ -697,7 +664,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         }
 
         // dont search illegal moves
-        if (!b->isLegal(m)) {
+        if ((inCheck || ((ONE << getSquareFrom(m)) & okingCBB)) ? !b->isLegal(m) : 0) {
             quiets -= quiet;
             continue;
         }


### PR DESCRIPTION
bench: 3630113

Tested twice as usual:
ELO   | 3.04 +- 2.26 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 45104 W: 11416 L: 11022 D: 22666

ELO   | 3.76 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 33480 W: 8460 L: 8098 D: 16922