### PR TITLE
Remove tempo bonus

### DIFF
--- a/src_files/Board.cpp
+++ b/src_files/Board.cpp
@@ -1439,5 +1439,5 @@ Score Board::evaluate(){
                    - phaseValues[3] * bitCount(getPieceBB()[WHITE_ROOK] | getPieceBB()[BLACK_ROOK])
                    - phaseValues[4] * bitCount(getPieceBB()[WHITE_QUEEN] | getPieceBB()[BLACK_QUEEN]))
                   / 24.0f;
-    return (2.0f - phase) * 0.8f * (this->evaluator.evaluate(this->getActivePlayer()) + 10);
+    return (2.0f - phase) * 0.8f * (this->evaluator.evaluate(this->getActivePlayer()));
 }


### PR DESCRIPTION
bench: 3963416

Tested twice as usual:
ELO   | 1.86 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 101000 W: 25113 L: 24572 D: 51315

ELO   | 1.20 +- 0.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 351856 W: 87280 L: 86068 D: 178508