### PR TITLE
Low depth singular extensions

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -714,7 +714,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                && !isCapture(hashMove)
                &&  sameMove(m, hashMove)
                &&  ply >  0
-               &&  sd->eval[b->getActivePlayer()][ply] < alpha - 50
+               &&  sd->eval[b->getActivePlayer()][ply] < alpha - 25
                &&  en.type == CUT_NODE) {
             extension = 1;
         }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -711,9 +711,8 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         } else if (depth < 8
                && !skipMove
                && !inCheck
-               && !isCapture(hashMove)
                &&  sameMove(m, hashMove)
-               &&  ply >  0
+               &&  ply > 0
                &&  sd->eval[b->getActivePlayer()][ply] < alpha - 25
                &&  en.type == CUT_NODE) {
             extension = 1;

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -708,6 +708,15 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
             if (legalMoves == 0) {
                 sd->reduce = true;
             }
+        } else if (depth < 8
+               && !skipMove
+               && !inCheck
+               && !isCapture(hashMove)
+               &&  sameMove(m, hashMove)
+               &&  ply >  0
+               &&  sd->eval[b->getActivePlayer()][ply] < alpha - 50
+               &&  en.type == CUT_NODE) {
+            extension = 1;
         }
 
         U64   nodeCount = td->nodes;


### PR DESCRIPTION
bench: 4592931

Low depth singular extension idea. Determine singularity by static evaluation vs alpha.

Tested twice as usual:
ELO   | 2.77 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 51960 W: 13125 L: 12711 D: 26124
ELO   | 8.29 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 12824 W: 3320 L: 3014 D: 6490