### PR TITLE
Hashtweaks

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -914,11 +914,11 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         } else {
             if (hashMove && en.type == CUT_NODE) {
                 bestMove = en.move;
-            } else if (score == alpha && !sameMove(hashMove, bestMove)) {
+            } else if (highestScore == alpha && !sameMove(hashMove, bestMove)) {
                 bestMove = 0;
             }
 
-            if (depth > 7 && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
+            if (depth > 7 && bestMove && (td->nodes - prevNodeCount) / 2 < bestNodeCount) {
                 table->put(key, highestScore, bestMove, FORCED_ALL_NODE, depth,
                            sd->eval[b->getActivePlayer()][ply]);
             } else {


### PR DESCRIPTION
bench: 4471011

Tweak hash move updating. Really just a fix to something that already somehow gained before. 

Tested twice as usual:
ELO   | 1.82 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 103816 W: 25453 L: 24908 D: 53455

ELO   | 2.44 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 62488 W: 15521 L: 15083 D: 31884