### PR TITLE
speedup addQuiet

### DIFF
--- a/src_files/History.h
+++ b/src_files/History.h
@@ -26,27 +26,27 @@
 struct SearchData {
     move::Move     bestMove = 0;
     // Effort spent
-    int64_t  spentEffort[bb::N_SQUARES][bb::N_SQUARES]                                               = {0};
+    int64_t  spentEffort[bb::N_SQUARES][bb::N_SQUARES]                                                      = {0};
     // EvalImprovement
-    int      maxImprovement[bb::N_SQUARES][bb::N_SQUARES]                                            = {0};
+    int      maxImprovement[bb::N_SQUARES][bb::N_SQUARES]                                                   = {0};
     // capture history table (side-from-to)
-    int      captureHistory[bb::N_COLORS][bb::N_SQUARES * bb::N_SQUARES]                             = {0};
+    int      captureHistory[bb::N_COLORS][bb::N_SQUARES * bb::N_SQUARES]                                    = {0};
     // threat history
-    int      th[bb::N_COLORS][bb::N_SQUARES + 1][bb::N_SQUARES * bb::N_SQUARES]                      = {0};
+    int      th[bb::N_COLORS][bb::N_SQUARES + 1][bb::N_SQUARES * bb::N_SQUARES]                             = {0};
     // counter move history table (prev_piece, prev_to, side, move_piece, move_to)
-    int      cmh[bb::N_PIECE_TYPES * bb::N_SQUARES][bb::N_COLORS][bb::N_PIECE_TYPES * bb::N_SQUARES] = {0};
+    int      cmh[bb::N_PIECE_TYPES * bb::N_SQUARES][bb::N_COLORS][bb::N_PIECE_TYPES * bb::N_SQUARES]        = {0};
     // followup move history
-    int      fmh[bb::N_PIECE_TYPES * bb::N_SQUARES][bb::N_COLORS][bb::N_PIECE_TYPES * bb::N_SQUARES] = {0};
+    int      fmh[bb::N_PIECE_TYPES * bb::N_SQUARES + 1][bb::N_COLORS][bb::N_PIECE_TYPES * bb::N_SQUARES]    = {0};
     // kill table, +2 used to make sure we can always reset +2
-    move::Move     killer[bb::N_COLORS][bb::MAX_INTERNAL_PLY + 2][2]                                 = {0};
+    move::Move     killer[bb::N_COLORS][bb::MAX_INTERNAL_PLY + 2][2]                                        = {0};
     // threat data
-    int      threatCount[bb::MAX_INTERNAL_PLY][bb::N_COLORS]                                         = {0};
-    bb::Square   mainThreat[bb::MAX_INTERNAL_PLY]                                                    = {0};
+    int      threatCount[bb::MAX_INTERNAL_PLY][bb::N_COLORS]                                                = {0};
+    bb::Square   mainThreat[bb::MAX_INTERNAL_PLY]                                                           = {0};
     // eval history across plies
-    bb::Score    eval[bb::N_COLORS][bb::MAX_INTERNAL_PLY]                                            = {0};
+    bb::Score    eval[bb::N_COLORS][bb::MAX_INTERNAL_PLY]                                                   = {0};
     bool     sideToReduce;
     bool     reduce;
-    bool     targetReached                                                                           = 1;
+    bool     targetReached                                                                                  = 1;
 
     [[nodiscard]] int  getHistories(move::Move m, bb::Color side, move::Move previous, move::Move followup, bb::Square threatSquare) const;
 

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -49,6 +49,9 @@ void moveGen::init(SearchData* sd, Board* b, Depth ply, Move hashMove, Move prev
     m_killer2       = m_sd->killer[c][m_ply][1];
     m_threatSquare  = threatSquare;
     m_checkerSq     = checkerSq;
+    m_cmh           = &sd->cmh[getPieceTypeSqToCombination(previous)][c][0];
+    m_fmh           = &sd->fmh[followup ? getPieceTypeSqToCombination(followup) : 384][c][0];
+    m_th            = &sd->th[c][m_threatSquare][0];
 }
 
 Move moveGen::next() {
@@ -139,7 +142,9 @@ void moveGen::addQuiet(Move m) {
     if (sameMove(m_hashMove, m) || sameMove(m_killer1, m) || sameMove(m_killer2, m))
         return;
     quiets[quietSize] = m;
-    quietScores[quietSize++] = m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare);
+    quietScores[quietSize++] = m_th[getSqToSqFromCombination(m)] 
+                             + m_cmh[getPieceTypeSqToCombination(m)] 
+                             + m_fmh[getPieceTypeSqToCombination(m)];
 }
 
 Move moveGen::nextNoisy() {

--- a/src_files/newmovegen.h
+++ b/src_files/newmovegen.h
@@ -75,6 +75,9 @@ class moveGen {
     move::Move      m_killer2;
     move::Move      m_previous;
     move::Move      m_followup;
+    int*            m_th;
+    int*            m_cmh;
+    int*            m_fmh;
     bb::Square      m_threatSquare;
     bb::U64         m_checkerSq;
     bb::Color       c;


### PR DESCRIPTION
bench: 4445089

Remove if statement etc.

Tested twice as usual:
ELO   | 3.32 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 39088 W: 9593 L: 9220 D: 20275

ELO   | 3.58 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 35400 W: 8735 L: 8370 D: 18295