### PR TITLE
Scale evaluation by 1.25x

### DIFF
--- a/src_files/Board.cpp
+++ b/src_files/Board.cpp
@@ -1418,5 +1418,5 @@ template<Color side> U64 Board::getPinnedPieces(U64& pinners) const {
 }
 
 Score Board::evaluate(){
-    return 1.06 * this->evaluator.evaluate(this->getActivePlayer());
+    return 1.25 * this->evaluator.evaluate(this->getActivePlayer());
 }


### PR DESCRIPTION
bench: 4428076

Scale eval by 1.25x instead of the previous 1.06.

Tested twice:
ELO   | 2.68 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 52936 W: 12884 L: 12476 D: 2757
ELO   | 5.65 +- 3.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 19680 W: 4843 L: 4523 D: 10314