### PR TITLE
Optimize good capture sorting

### DIFF
--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -129,7 +129,7 @@ void moveGen::addNoisy(Move m) {
     noisySee[noisySize] = score;
     int mvvLVA  = piece_values[(getCapturedPieceType(m))];
     if (score >= 0) {
-        score = 100000 + mvvLVA + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare);
+        score = 100000 + mvvLVA + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare) + (getSquareTo(m) == getSquareTo(m_previous)) * 100;
         goodNoisyCount++;
     } else {
         score = 10000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare);

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -127,9 +127,9 @@ void moveGen::addNoisy(Move m) {
         return;
     int score   = m_board->staticExchangeEvaluation(m);
     noisySee[noisySize] = score;
-    int mvvLVA  = piece_values[(getCapturedPieceType(m))];
+    //int mvvLVA  = piece_values[(getCapturedPieceType(m))];
     if (score >= 0) {
-        score = 100000 + mvvLVA + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare) + (getSquareTo(m) == getSquareTo(m_previous)) * 100;
+        score = 100000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare) + score;
         goodNoisyCount++;
     } else {
         score = 10000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare);

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -129,7 +129,7 @@ void moveGen::addNoisy(Move m) {
     noisySee[noisySize] = score;
     //int mvvLVA  = piece_values[(getCapturedPieceType(m))];
     if (score >= 0) {
-        score = 100000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare) + score;
+        score = 100000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare) + score  + 150 * (getSquareTo(m) == getSquareTo(m_previous));
         goodNoisyCount++;
     } else {
         score = 10000 + m_sd->getHistories(m, c, m_previous, m_followup, m_threatSquare);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -44,8 +44,8 @@ int  LMR_DIV          = 267;
 
 int  lmp[2][8]        = {{0, 2, 3, 5, 8, 12, 17, 23}, {0, 3, 6, 9, 12, 18, 28, 40}};
 
-int64_t capn;
-int64_t capcn;
+//int64_t capn;
+//int64_t capcn;
 
 /**
  * =================================================================================
@@ -300,7 +300,7 @@ Move Search::bestMove(Board* b, TimeManager* timeman, int threadId) {
             break;
     }
 
-    std::cout << capcn * 10000 / capn;
+    //std::cout << capcn * 10000 / capn;
     // if the main thread finishes, we will record the data of this thread
     if (threadId == 0) {
         // tell all other threads if they are running to stop the search
@@ -867,10 +867,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // beta -cutoff
         if (score >= beta) {
 
-            if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
-                capn++;
-                capcn += legalMoves;
-            }
+            //if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
+                //capn++;
+                //capcn += legalMoves;
+            //}
 
             if (!skipMove && !td->dropOut) {
                 // put the beta cutoff into the perft_tt

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -44,6 +44,9 @@ int  LMR_DIV          = 267;
 
 int  lmp[2][8]        = {{0, 2, 3, 5, 8, 12, 17, 23}, {0, 3, 6, 9, 12, 18, 28, 40}};
 
+//int64_t capn;
+//int64_t capcn;
+
 /**
  * =================================================================================
  *                              S E A R C H
@@ -297,6 +300,7 @@ Move Search::bestMove(Board* b, TimeManager* timeman, int threadId) {
             break;
     }
 
+    //std::cout << capcn * 10000 / capn;
     // if the main thread finishes, we will record the data of this thread
     if (threadId == 0) {
         // tell all other threads if they are running to stop the search
@@ -862,6 +866,12 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
 
         // beta -cutoff
         if (score >= beta) {
+
+            //if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
+            //    capn++;
+            //    capcn += legalMoves;
+            //}
+
             if (!skipMove && !td->dropOut) {
                 // put the beta cutoff into the perft_tt
                 table->put(key, score, m, CUT_NODE, depth, sd->eval[b->getActivePlayer()][ply]);

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -44,8 +44,8 @@ int  LMR_DIV          = 267;
 
 int  lmp[2][8]        = {{0, 2, 3, 5, 8, 12, 17, 23}, {0, 3, 6, 9, 12, 18, 28, 40}};
 
-//int64_t capn;
-//int64_t capcn;
+int64_t capn;
+int64_t capcn;
 
 /**
  * =================================================================================
@@ -300,7 +300,7 @@ Move Search::bestMove(Board* b, TimeManager* timeman, int threadId) {
             break;
     }
 
-    //std::cout << capcn * 10000 / capn;
+    std::cout << capcn * 10000 / capn;
     // if the main thread finishes, we will record the data of this thread
     if (threadId == 0) {
         // tell all other threads if they are running to stop the search
@@ -867,10 +867,10 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // beta -cutoff
         if (score >= beta) {
 
-            //if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
-            //    capn++;
-            //    capcn += legalMoves;
-            //}
+            if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
+                capn++;
+                capcn += legalMoves;
+            }
 
             if (!skipMove && !td->dropOut) {
                 // put the beta cutoff into the perft_tt

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -44,9 +44,6 @@ int  LMR_DIV          = 267;
 
 int  lmp[2][8]        = {{0, 2, 3, 5, 8, 12, 17, 23}, {0, 3, 6, 9, 12, 18, 28, 40}};
 
-//int64_t capn;
-//int64_t capcn;
-
 /**
  * =================================================================================
  *                              S E A R C H
@@ -300,7 +297,6 @@ Move Search::bestMove(Board* b, TimeManager* timeman, int threadId) {
             break;
     }
 
-    //std::cout << capcn * 10000 / capn;
     // if the main thread finishes, we will record the data of this thread
     if (threadId == 0) {
         // tell all other threads if they are running to stop the search
@@ -866,12 +862,6 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
 
         // beta -cutoff
         if (score >= beta) {
-
-            //if (!sameMove(m, hashMove) && isCapture(m) && quiets < 2) {
-                //capn++;
-                //capcn += legalMoves;
-            //}
-
             if (!skipMove && !td->dropOut) {
                 // put the beta cutoff into the perft_tt
                 table->put(key, score, m, CUT_NODE, depth, sd->eval[b->getActivePlayer()][ply]);


### PR DESCRIPTION
bench: 4696747

Optimize sorting of good captures by measuring average played captures when there is a cutoff.

Tested twice:
ELO   | 1.43 +- 1.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 181288 W: 43649 L: 42905 D: 94734

ELO   | 1.41 +- 1.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 185224 W: 44446 L: 43694 D: 97084