### PR TITLE
fix draw mr50 and checkmate + simplified fen reading

### DIFF
--- a/src_files/board.cpp
+++ b/src_files/board.cpp
@@ -57,11 +57,7 @@ Board::Board(const std::string& fen) {
     this->m_boardStatusHistory.push_back(boardStatus);
     
     // using some string utilties defined in Util.h, we split the fen into parts.
-    std::vector<std::string> split;
-    std::string              str {fen};
-    str = trim(str);
-    findAndReplaceAll(str, "  ", " ");
-    splitString(str, split, ' ');
+    std::vector<std::string> split = split_input_fen(fen);
     
     // first we parse the pieces on the board.
     File x {0};
@@ -132,13 +128,19 @@ Board::Board(const std::string& fen) {
         }
     }
     
-    // the last thing we consider is e.p. square.
+    // e.p. square.
     if (split.size() >= 4) {
         if (split[3].at(0) != '-') {
             Square square = squareIndex(split[3]);
             setEnPassantSquare(square);
         }
     }
+    
+    if (split.size() >= 5)
+        getBoardStatus()->fiftyMoveCounter = std::stoi(split[4]);
+
+    if (split.size() >= 6) 
+        getBoardStatus()->moveCounter = std::stoi(split[5]);
     
     this->evaluator.reset(this);
     // note that we do not read information about move counts. This is usually not required for playing games.
@@ -559,7 +561,7 @@ template<bool prefetch> void Board::move(Move m, TranspositionTable* table) {
         // check if it crossed squares
         if(     nn::kingSquareIndex(sqTo, color) !=
                 nn::kingSquareIndex(sqFrom, color)
-            ||  fileIndex(sqFrom) + fileIndex(sqTo) == 7){
+                ||  fileIndex(sqFrom) + fileIndex(sqTo) == 7){
             this->evaluator.resetAccumulator(this, color);
         }
         
@@ -1305,8 +1307,9 @@ void Board::computeNewRepetition() {
     const int maxChecks = getBoardStatus()->fiftyMoveCounter;
     
     const int lim = m_boardStatusHistory.size() - 1 - maxChecks;
-    
-    for (int i = m_boardStatusHistory.size() - 3; i >= lim; i -= 2) {
+    const int end = std::max(0,lim);
+
+    for (int i = m_boardStatusHistory.size() - 3; i >= end; i -= 2) {
         if (m_boardStatusHistory.at(i).zobrist == getBoardStatus()->zobrist) {
             getBoardStatus()->repetitionCounter = m_boardStatusHistory.at(i).repetitionCounter + 1;
         }

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -372,18 +372,26 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         //  standard implementation in Koi
         //   Weiss now also has a similar implementation to Koi, but its unclear if it is better than
         //   standard either.
-
+        if (b->getCurrent50MoveRuleCount() >= 50 && b->isInCheck(b->getActivePlayer())) {
+            MoveList mv {};
+            generatePerftMoves(b, &mv);
+            for (size_t i = 0; i < mv.getSize(); i++) {
+                if (b->isLegal(mv.getMove(i)))
+                    return 8 - (td->nodes & MASK<4>);
+            }
+            return -MAX_MATE_SCORE + ply;
+        }
         return 8 - (td->nodes & MASK<4>);
     }
 
+    // check if the active player is in check. used for various pruning decisions.
+    bool inCheck = b->isInCheck(b->getActivePlayer());
+    
     // beside keeping track of the nodes, we need to keep track of the selective depth for this
     // thread.
     if (ply > td->seldepth) {
         td->seldepth = ply;
     }
-
-    // check if the active player is in check. used for various pruning decisions.
-    bool inCheck = b->isInCheck(b->getActivePlayer());
 
     // depth > MAX_PLY means that it overflowed because depth is unsigned.
     if (depth == 0 || depth > MAX_PLY || ply > MAX_PVSEARCH_PLY) {

--- a/src_files/util.cpp
+++ b/src_files/util.cpp
@@ -100,6 +100,24 @@ std::vector<std::string>& splitString(const std::string& txt, std::vector<std::s
 }
 
 /**
+ * splits the string into subparts
+ * @param fen
+ * @return
+ */
+std::vector<std::string> split_input_fen(std::string fen)
+{
+    std::stringstream fen_stream(fen);
+    std::string segment;
+    std::vector<std::string> seglist;
+
+    while (std::getline(fen_stream, segment, ' '))
+    {
+        seglist.push_back(segment);
+    }
+    return seglist;
+}
+
+/**
  * returns a loading bar as a string. Usually used together with '\r'.
  * @param count
  * @param max

--- a/src_files/util.h
+++ b/src_files/util.h
@@ -82,6 +82,14 @@ std::string&              findAndReplaceAll(std::string& data, const std::string
  */
 std::vector<std::string>& splitString(const std::string& txt, std::vector<std::string>& strs, char ch);
 
+
+/**
+ * splits the string into subparts
+ * @param fen
+ * @return
+ */
+std::vector<std::string> split_input_fen(std::string fen);
+
 /**
  * starts the time measurement.
  * Note that this Tool is not used during search but rather for internal profilings and debugging.


### PR DESCRIPTION
`2k5/5R2/3K4/8/8/8/8/8 w - - 99 99` is now correctly evaluated as a draw
`3k4/5R2/3K4/8/8/8/8/8 w - - 99 99` is now correctly evaluated as mate in 1
`2k5/1N3R2/3K4/8/8/8/8/8 w - - 99 99` is now correctly evaluated as a draw

1. problem was koi didnt read the halfmoves from the fen, (just assumed its 0)
2. mr50 draw + checkmate is a checkmate, koi thought its a draw (this happened at CCC against stockfish)

ob: http://chess.grantnet.us/test/26296/

this closes #201 

bench: 4020537