### PR TITLE
History bonus/penalty tweaks

### DIFF
--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -480,7 +480,7 @@ void moveGen::generateEvasions() {
 }
 
 void moveGen::updateHistory(int weight) {
-    weight          = std::min(weight * weight + 5 * weight, 256);
+    weight          = std::min(weight * weight + 5 * weight, 384);
     Move bestMove   = searched[searched_index - 1];    
 
     if (isCapture(bestMove)) {

--- a/src_files/newmovegen.cpp
+++ b/src_files/newmovegen.cpp
@@ -488,7 +488,7 @@ void moveGen::updateHistory(int weight) {
                     + weight
                     - weight * m_sd->captureHistory[c][getSqToSqFromCombination(bestMove)]
                     / MAX_HIST;
-
+        weight = std::min(weight, 128);
         for (int i = 0; i < searched_index - 1; i++) {
             Move m = searched[i];
             if (isCapture(m)) {
@@ -511,6 +511,7 @@ void moveGen::updateHistory(int weight) {
                     + weight
                     - weight * m_sd->fmh[getPieceTypeSqToCombination(m_followup)][c][getPieceTypeSqToCombination(bestMove)]
                     / MAX_HIST;
+        weight = std::min(weight, 128);
         for (int i = 0; i < searched_index - 1; i++) {
             Move m = searched[i];
             if (isCapture(m)) {


### PR DESCRIPTION
bench: 4398538

Reduced max history penalty & increased max history bonus.

Tested twice:
ELO   | 2.08 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 79512 W: 19053 L: 18578 D: 41881

ELO   | 3.50 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 36096 W: 8824 L: 8460 D: 18812