### PR TITLE
Fix probeDTZ move translation

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -1383,7 +1383,7 @@ Move Search::probeDTZ(Board* board) {
 
     // get the promotion piece if the target move is a promotion (this does not yet work the way it
     // should)
-    PieceType promo  = 6 - TB_GET_PROMOTES(result);
+    PieceType promo  = 5 - TB_GET_PROMOTES(result);
 
     // gets the square from and square to for the move which should be played
     Square    sqFrom = TB_GET_FROM(result);


### PR DESCRIPTION
Bench: 4124411

Syzygy maps pieces using the following combination:
1 - queen, 2 - rook, 3 - bishop, 4 - knight.

Koivisto incorrectly translates these to:
1 - king, 2 - queen, 3 -rook, 4 - bishop.

This position now translates to h7h8n rather than h7h8b,
`8/7P/8/8/8/3N4/k1K5/2B5 w - - 29 121`