### PR TITLE
fix tb dtz probing

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -1400,10 +1400,10 @@ Move Search::probeDTZ(Board* board) {
 
         // check if it's the same.
         if (getSquareFrom(m) == sqFrom && getSquareTo(m) == sqTo) {
-            if (   (    promo == 6
+            if (   (    promo == 5
                     && !isPromotion(m))
                 || (isPromotion(m)
-                    && promo < 6
+                    && promo < 5
                     && getPromotionPieceType(m) == promo)) {
                 std::cout << "info"
                           << " depth "      << static_cast<int>(dtz)


### PR DESCRIPTION
```
8/8/5K2/8/6k1/5r2/2Q5/8 w - - 0 1
8/6r1/2Q5/3K2k1/8/8/8/8 w - - 0 1
8/6K1/8/8/6k1/5r2/2Q5/8 b - - 0 1
```
Kovistio didnt play the shortest dtz move
in any of these positions (5 man)
probing was not successful in this loop

<https://github.com/Luecx/Koivisto/blob/ea5ae3df7c0ee0e00e0c77c2df741d7157b64d2f/src_files/search.cpp#L1397>

Koivisto only played the shortest dtz move in this position
```
8/7P/8/8/8/3N4/k1K5/2B5 w - - 0 1
``` 

<https://github.com/Luecx/Koivisto/commit/2b66e2870ed29e4de6ef64e28f2a1ea2920fcf5b> 
fixed promotion dtz's but didnt change the values thereafter, so it makes sense that
the dtz probing works for promotions but not for other positions.

Tested these changes on 
```
8/8/5K2/8/6k1/5r2/2Q5/8 w - - 0 1
8/6r1/2Q5/3K2k1/8/8/8/8 w - - 0 1
8/6K1/8/8/6k1/5r2/2Q5/8 b - - 0 1
```

the shortest dtz move is now played instantly...

bench: 4124411