### PR TITLE
Remove the ability to fail-high when razoring at depth 1

### DIFF
--- a/src_files/makefile
+++ b/src_files/makefile
@@ -12,7 +12,7 @@ _SRCS     := $(_SRC)/*.cpp $(_SRC)/syzygy/tbprobe.cpp
 
 # engine name and version
 NAME       = Koivisto
-MINOR      = 13
+MINOR      = 14
 MAJOR      = 8
 MAKROS     = -DMINOR_VERSION=$(MINOR) -DMAJOR_VERSION=$(MAJOR)
 

--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -578,10 +578,8 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
         // **********************************************************************************************************
         if (depth <= 3 && staticEval + RAZOR_MARGIN * depth < beta) {
             score = qSearch(b, alpha, beta, ply, td);
-            if (score < beta) {
+            if (score < beta)
                 return score;
-            } else if (depth == 1)
-                return beta;
         }
         // *******************************************************************************************
         // static null move pruning:


### PR DESCRIPTION
Bench: 3999616

Removes the ability to fail-high when razoring at depth 1. 

This is to potentially address the issue seen in [this game](https://tcec-chess.com/#div=l1&game=2&season=23) where Koivisto saw a tablebase win (47 ply out), but refused to progress. Analysis of the position `8/2k5/P7/2bPp3/K1B1P3/8/8/8 w - - 31 85` shows that Koivisto has a tendency to stagnate it's eval when this condition is present (see [this message](https://discord.com/channels/675365694300225568/951089902991335424/1017826412448731147)). With the removal of this condition, the analysis steadily rises (see [this message](https://discord.com/channels/675365694300225568/951089902991335424/1017825022661890109)).

This was tested at STC with regression bounds [-2.5, 0.5] - http://chess.grantnet.us/test/28418/
```
ELO   | 0.54 +- 1.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-2.50, 0.50]
GAMES | N: 61472 W: 14680 L: 14584 D: 32208
```
