### PR TITLE
2 yellow search tweaks combined

### DIFF
--- a/src_files/search.cpp
+++ b/src_files/search.cpp
@@ -799,6 +799,7 @@ Score Search::pvSearch(Board* b, Score alpha, Score beta, Depth depth, Depth ply
                 lmr--;
             if (sd->reduce && sd->sideToReduce != b->getActivePlayer())
                 lmr++;
+            lmr += std::min(2, std::abs(staticEval - alpha) / 350);
             lmr -= bitCount(getNewThreats(b, m));
             if (lmr > MAX_PLY) {
                 lmr = 0;

--- a/src_files/transpositiontable.cpp
+++ b/src_files/transpositiontable.cpp
@@ -141,7 +141,7 @@ bool TranspositionTable::put(bb::U64 zobrist, bb::Score score, move::Move move, 
         if (   enP->getAge() != m_currentAge
             || type == PV_NODE
             || (enP->type    != PV_NODE && enP->depth <= depth)
-            || (enP->zobrist == key     && enP->depth <= depth * 2)) {
+            || (enP->zobrist == key     && enP->depth <= depth + 3)) {
             enP->set(key, score, move, type, depth, eval);
             enP->setAge(m_currentAge);
             return true;


### PR DESCRIPTION
bench: 3983323

2 yellows combined

tested twice as usual:
ELO   | 1.61 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 134912 W: 32642 L: 32016 D: 70254

ELO   | 1.31 +- 0.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.50]
GAMES | N: 234376 W: 56593 L: 55709 D: 12207